### PR TITLE
Terminate the build script once the build is successfully compiled.

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -107,6 +107,7 @@ checkBrowsers(paths.appPath, isInteractive)
         buildFolder,
         useYarn
       );
+      process.exit(0);
     },
     err => {
       const tscCompileOnError = process.env.TSC_COMPILE_ON_ERROR === 'true';


### PR DESCRIPTION
Pilot partner noticed an issue where you had to manually terminate the process after running `npm run build` or `npm run build-windows`. This allows the process to terminate once the build has been successfully compiled.