### PR TITLE
Fix await error and error in the way fsh objects are parsed

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -107,6 +107,7 @@ checkBrowsers(paths.appPath, isInteractive)
         buildFolder,
         useYarn
       );
+      process.exit(0);
     },
     err => {
       const tscCompileOnError = process.env.TSC_COMPILE_ON_ERROR === 'true';

--- a/src/smart/SmartPatient.js
+++ b/src/smart/SmartPatient.js
@@ -17,7 +17,7 @@ export function SmartPatient() {
       let newData = [];
       let client = await FHIR.oauth2.ready();
 
-      const fhirParser = boundParser(newData);
+      const fhirParser = await boundParser(newData);
 
       let pid = await client.patient.read().then(async function(pt) {
         await fhirParser(pt);
@@ -140,6 +140,10 @@ export function SmartPatient() {
 }
 
 function cleanFsh(fsh) {
+  if (typeof fsh != "string") {
+    let fshString = fsh.fsh;
+    return fshString.replaceAll('undefined', ',').replaceAll(',', '\n');
+  }
   return fsh.replaceAll('undefined', ',').replaceAll(',', '\n');
 }
 

--- a/src/smart/SmartPatient.js
+++ b/src/smart/SmartPatient.js
@@ -140,11 +140,8 @@ export function SmartPatient() {
 }
 
 function cleanFsh(fsh) {
-  if (typeof fsh != "string") {
-    let fshString = fsh.fsh;
-    return fshString.replaceAll('undefined', ',').replaceAll(',', '\n');
-  }
-  return fsh.replaceAll('undefined', ',').replaceAll(',', '\n');
+  const fshString = typeof fsh === "string" ? fsh : fsh.fsh;
+  return fshString.replaceAll('undefined', '\n').replaceAll(',', '\n');
 }
 
 async function boundParser(data) {


### PR DESCRIPTION
Testing with a synthetic patient using https://launch.smarthealthit.org/ displays the following:

![Screen Shot 2023-05-16 at 1 26 13 AM](https://github.com/ccsm-cds-tools/ccsm-cds-dashboard/assets/51176978/b8d416b5-5b68-4d46-bd92-407d9527e106)

It runs slowly, even in production mode using the build version of the app, but this is because the test patient in question is very large. In pilot testing, the test patients should have a more limited amount of resources to pull in and convert to FSH.