### PR TITLE
Fix recommendation details is null

### DIFF
--- a/src/smart/SmartPatient.js
+++ b/src/smart/SmartPatient.js
@@ -149,13 +149,23 @@ function displayRecommendations(decisionAids) {
   }
 
   const {
-    recommendation,
-    recommendationGroup,
-    recommendationDate,
-    recommendationDetails,
+    recommendation = '',
+    recommendationGroup = '',
+    recommendationDate = '',
+    recommendationDetails = [],
+    errors=[]
   } = decisionAids;
 
-  const output = `Recommendations: ${recommendation}\n${recommendationGroup}\nDue: ${recommendationDate}\n---\n${recommendationDetails ? recommendationDetails.join('\n') : ''}`;
+  let output = '';
+
+  if (errors.length > 0) {
+    output = `Cannot Make Recommendation.\n---\n${errors.join('\n')}`;
+  } else {
+    const formattedRecommendation = recommendation === '' ? 'No Recommendation' : recommendation;
+    const formattedRecommendationDate = recommendationDate !== '' ? `Due: ${recommendationDate}` : '';
+
+    output = `Recommendations: ${formattedRecommendation}\n${recommendationGroup}\n${formattedRecommendationDate}\n---\n${recommendationDetails.join('\n')}`;
+  }
 
   return output;
 }

--- a/src/smart/SmartPatient.js
+++ b/src/smart/SmartPatient.js
@@ -145,7 +145,7 @@ export function SmartPatient() {
 
 function displayRecommendations(decisionAids) {
   if (!decisionAids) {
-    return 'Recommendation: ';
+    return 'Waiting for recommendations ...';
   }
 
   const {
@@ -155,7 +155,7 @@ function displayRecommendations(decisionAids) {
     recommendationDetails,
   } = decisionAids;
 
-  const output = `Recommendations: ${recommendation}\n${recommendationGroup}\nDue: ${recommendationDate}\n---\n${recommendationDetails.join('\n')}`;
+  const output = `Recommendations: ${recommendation}\n${recommendationGroup}\nDue: ${recommendationDate}\n---\n${recommendationDetails ? recommendationDetails.join('\n') : ''}`;
 
   return output;
 }


### PR DESCRIPTION
This PR fixed an error in debug mode when recommendationDetails is null.

This PR changed the initial output to "Waiting for recommendation ... " to avoid confusion.

This PR also update the recommendation output using the format the logic from regular HTML output, including showing error messages from decisionAids.