### PR TITLE
Translate.js Bug: Coding element within new valueCodeableConcept should be an array

### DIFF
--- a/src/hooks/useCds/translate.js
+++ b/src/hooks/useCds/translate.js
@@ -174,10 +174,10 @@ function mapResult(result, loincMapping, testCodeResultMapping) {
 
     if (mappedCode) {
       result.valueCodeableConcept = {
-        coding: {
+        coding: [{
           system: SCT_URL,
           code: mappedCode.code
-        },
+        }],
         text: result.valueString
       };
 


### PR DESCRIPTION
When translating a valueString into a valueCodeableConcept in an incoming test result, the coding element within the new valueCodeableConcept that is created should be an array, not an object.