### PR TITLE
Add extra NILM text value to lab result mapping

### DIFF
--- a/src/hooks/useCds/translate.js
+++ b/src/hooks/useCds/translate.js
@@ -90,6 +90,10 @@ const testCodeResultMapping = [
       {
         text: "Reparative/reactive changes",
         code: "373887005"
+      },
+      {
+        text: "Other, see comment",
+        code: "126481000119106"
       }
     ]
   },

--- a/src/hooks/useCds/translate.js
+++ b/src/hooks/useCds/translate.js
@@ -4,6 +4,10 @@ const testCodeResultMapping = [
     testName: 'Cytology',
     map: [
       {
+        text: "Negative for intraepithelial lesion or malignancy",
+        code: "373887005"
+      },
+      {
         text: "Negative for intraepithelial lesion or malignancy, atrophic pattern",
         code: "373887005"
       },


### PR DESCRIPTION
[UMMC Lab Mappings.xlsx](https://mitre.sharepoint.com/:x:/r/sites/CervicalCancerCDS/Shared%20Documents/Pilot%20Task/UMMC%20Pilot/UMMC%20Data%20Mapping/Lab%20Test%20and%20Result%20Mapping/UMMC%20Lab%20Mappings.xlsx?d=w358d894df255428785601d4a3b923f45&csf=1&web=1&e=mWs7Bt) was missing a cytology mapping for the valueString of "_Negative for intraepithelial lesion or malignancy_", which could be sent over by UMMC to represent a NILM cytology result. This PR adds mapping for this value to the NILM SNOMED-CT code. Thanks @yunwwang for tracking this down!