### PR TITLE
Restore patient history section to dashboard

### DIFF
--- a/src/smart/SmartPatient.js
+++ b/src/smart/SmartPatient.js
@@ -3,6 +3,7 @@ import FHIR from 'fhirclient';
 
 import Dashboard from 'features/Dashboard';
 import { useCds } from 'hooks/useCds';
+import { config } from './smart.config.js';
 
 export function SmartPatient() {
 
@@ -134,7 +135,7 @@ export function SmartPatient() {
       <div className="content">
         <Dashboard
           input={dashboardInput}
-          config={{}}
+          config={config}
           setPatientData={setPatientData}
         />
       </div>


### PR DESCRIPTION
This will restore the patient history section to the dashboard display. It looks like this was removed when the code for the debug mode was created:
- PR: https://github.com/ccsm-cds-tools/ccsm-cds-dashboard/pull/10
- Commit: https://github.com/ccsm-cds-tools/ccsm-cds-dashboard/commit/7f6ef3391690de1326356c3075965ddcc01b61e4

Here is a screenshot of the dashboard when run with a patient who has an HPV test and a Cervix Excision. You can now see these results in the dashboard display. Prior to this pull request, the _Relevant Medical History_, _Screening and Management History_, and _Vaccination History_ sections would not be present.

![Dashboard with Patient History Restored](https://github.com/ccsm-cds-tools/ccsm-cds-dashboard/assets/51176978/0ebd4f17-da90-4ba8-9b1f-3ee9fe8bd202)
