### PR TITLE
CCSMCDS-70 - Dashboard throws error when an Observation has no code

### DIFF
--- a/src/hooks/useCds/translate.js
+++ b/src/hooks/useCds/translate.js
@@ -171,6 +171,8 @@ function mapLoincCode(result, loincMapping) {
 }
 
 function mapResult(result, loincMapping, testCodeResultMapping) {
+  if (!result.code.coding || !result.code.coding.length > 0) {return};
+  
   mapLoincCode(result, loincMapping);
 
   const customCodes = testCodeResultMapping.find(ts =>

--- a/src/hooks/useCds/translate.js
+++ b/src/hooks/useCds/translate.js
@@ -171,8 +171,7 @@ function mapLoincCode(result, loincMapping) {
 }
 
 function mapResult(result, loincMapping, testCodeResultMapping) {
-  if (!result.code.coding || !result.code.coding.length > 0) {return};
-  
+  if (!result.code.coding?.length) { return; }
   mapLoincCode(result, loincMapping);
 
   const customCodes = testCodeResultMapping.find(ts =>


### PR DESCRIPTION
**Issue**
Currently, if an Observation is sent to our CDS, we will try to map the `code` and `valueCodeableConcept` elements in [translate.js](https://github.com/ccsm-cds-tools/ccsm-cds-dashboard/blob/pilot/src/hooks/useCds/translate.js#L148). However, if an Observation contains only an Observation.code.text field and not Observation.code.coding field, then this translation code throws an error, since we are trying to access a code from an array that doesn't exist. This was causing errors to be thrown by the dashboard when testing Patient 35, as well as when testing one of the pregnancy patients.

**What this pull request does**
Escape mapResult() function if there are no elements in result.code.coding. If an Observation has no code.coding, then there will be no loincMapping, and as a result, this Observation will be ignored by our CDS.

**Note**
In theory, another way to filter out Observations with no codes could be to add a parameter such as '&code:missing=false' to the Observation.Search query. However, the code:missing parameter is not supported by our pilot partner's EHR.