### PR TITLE
CCSMCDS-98 fix EpisodeOfCare search issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ You can run the dashboard locally by following these steps:
 ### Configuring Dashboard Environment
 CCSM CDS Dashboard relies on environment variables for configuration. Configuration options are described in the [Environment Setting for Dashboard](https://github.com/ccsm-cds-tools/ccsm-cds-dashboard/wiki/Environment-Setting-for-Dashboard) section of the Wiki.
 
+### Environment Variables to be set
+There are several environment variables to be set for dashbard to run:
+- `REACT_APP_CCSM_EPISODEOFCARE_TYPES`: This is the search value for EpisodeOfCare type search. The value shall be in a string of `[system]|[code]`. If the environment value is not set, the default value `urn:oid:1.2.840.114350.1.13.284.2.7.4.726668.130|2` will be used.
+- `REACT_APP_CCSM_OBSERVATION_CATEGORIES`: This is the search value for Observation category search. The value shall be a string of comma seperated category codes. If the environment value is not set, the default value `laboratory;obstetrics-gynecology;smartdata` will be used.
+
 ### Download Value Sets
 If your CDS uses value sets from the [Value Set Authority Center (VSAC)](https://vsac.nlm.nih.gov/) you must download your value sets from VSAC using your [Unified Medical Language System (UMLS)](https://www.nlm.nih.gov/research/umls/index.html) API key. This will require creating a free Unified Medical Language System (UMLS) account from the National Library of Medicine (NLM).  If you do not yet have an account, [sign up here](https://uts.nlm.nih.gov//license.html).
 

--- a/README.md
+++ b/README.md
@@ -29,11 +29,6 @@ You can run the dashboard locally by following these steps:
 ### Configuring Dashboard Environment
 CCSM CDS Dashboard relies on environment variables for configuration. Configuration options are described in the [Environment Setting for Dashboard](https://github.com/ccsm-cds-tools/ccsm-cds-dashboard/wiki/Environment-Setting-for-Dashboard) section of the Wiki.
 
-### Environment Variables to be set
-There are several environment variables to be set for dashbard to run:
-- `REACT_APP_CCSM_EPISODEOFCARE_TYPES`: This is the search value for EpisodeOfCare type search. The value shall be in a string of `[system]|[code]`. If the environment value is not set, the default value `urn:oid:1.2.840.114350.1.13.284.2.7.4.726668.130|2` will be used.
-- `REACT_APP_CCSM_OBSERVATION_CATEGORIES`: This is the search value for Observation category search. The value shall be a string of comma seperated category codes. If the environment value is not set, the default value `laboratory;obstetrics-gynecology;smartdata` will be used.
-
 ### Download Value Sets
 If your CDS uses value sets from the [Value Set Authority Center (VSAC)](https://vsac.nlm.nih.gov/) you must download your value sets from VSAC using your [Unified Medical Language System (UMLS)](https://www.nlm.nih.gov/research/umls/index.html) API key. This will require creating a free Unified Medical Language System (UMLS) account from the National Library of Medicine (NLM).  If you do not yet have an account, [sign up here](https://uts.nlm.nih.gov//license.html).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccsm-cds-dashboard",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ccsm-cds-dashboard",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",
@@ -39,7 +39,7 @@
         "css-minimizer-webpack-plugin": "^3.2.0",
         "dotenv": "^10.0.0",
         "dotenv-expand": "^5.1.0",
-        "encender": "^0.7.0",
+        "encender": "^0.7.1",
         "eslint": "^8.3.0",
         "eslint-config-react-app": "^7.0.1",
         "eslint-webpack-plugin": "^3.1.1",
@@ -11676,11 +11676,13 @@
       }
     },
     "node_modules/cql-execution": {
-      "version": "2.4.1",
-      "license": "Apache-2.0",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.1.tgz",
+      "integrity": "sha512-RC6uxrzvrJImFvyKvYDNLdumCS7nufJobhz5abfV3ZeFxbPR6E2gqJcn0T2KxVh4y40+BqbSGABwgiFTEITCdQ==",
       "dependencies": {
         "@lhncbc/ucum-lhc": "^4.1.3",
-        "luxon": "^1.25.0"
+        "immutable": "^4.1.0",
+        "luxon": "^1.28.1"
       }
     },
     "node_modules/cql-testing": {
@@ -11745,12 +11747,12 @@
       }
     },
     "node_modules/cql-worker": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/cql-worker/-/cql-worker-1.1.6.tgz",
-      "integrity": "sha512-J1QEk23Zd8WQeFp01bWwI+Uc4VwERr2GyCCSzqFnYoAGXVaDygmXw1D6c90nuvBeRNtazYkzybx0dyRzjMn36A==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/cql-worker/-/cql-worker-1.1.7.tgz",
+      "integrity": "sha512-wSjavK9yyhaqa4VGO8QcTZJuw5lN7bk3kYscbTt9xHJdudczIY8rQS967eyBsTba1lGrjsN9uKAFAPqPd4RuoA==",
       "dependencies": {
         "cql-exec-fhir": "^2.1.4",
-        "cql-execution": "^2.4.0"
+        "cql-execution": "^3.0.1"
       }
     },
     "node_modules/create-ecdh": {
@@ -12791,12 +12793,12 @@
       "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
     },
     "node_modules/encender": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/encender/-/encender-0.7.0.tgz",
-      "integrity": "sha512-DASkDK6A9Xk+ZUSCmJGOM0KlYbH5D39KBGAKRBe7SXx+cngTrQwPh8vxmz3EXs8D0yYB/xhoVWKA82j1WbJR3g==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/encender/-/encender-0.7.1.tgz",
+      "integrity": "sha512-7w27zgCQ5zIaXdPIPfq/iwlaWgbw+gCPaIOFJsQL313Pf2sYmlDeUH8WHTtMSMVv4m+YpguYMVBFP7kAXw8ClQ==",
       "dependencies": {
         "@asymmetrik/fhir-json-schema-validator": "^0.9.8",
-        "cql-worker": "^1.1.6",
+        "cql-worker": "^1.1.7",
         "semver": "^6.3.0"
       }
     },
@@ -24846,8 +24848,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.0.0",
-      "license": "MIT"
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
+      "integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA=="
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -46868,10 +46871,13 @@
       }
     },
     "cql-execution": {
-      "version": "2.4.1",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.1.tgz",
+      "integrity": "sha512-RC6uxrzvrJImFvyKvYDNLdumCS7nufJobhz5abfV3ZeFxbPR6E2gqJcn0T2KxVh4y40+BqbSGABwgiFTEITCdQ==",
       "requires": {
         "@lhncbc/ucum-lhc": "^4.1.3",
-        "luxon": "^1.25.0"
+        "immutable": "^4.1.0",
+        "luxon": "^1.28.1"
       }
     },
     "cql-testing": {
@@ -46923,12 +46929,12 @@
       }
     },
     "cql-worker": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/cql-worker/-/cql-worker-1.1.6.tgz",
-      "integrity": "sha512-J1QEk23Zd8WQeFp01bWwI+Uc4VwERr2GyCCSzqFnYoAGXVaDygmXw1D6c90nuvBeRNtazYkzybx0dyRzjMn36A==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/cql-worker/-/cql-worker-1.1.7.tgz",
+      "integrity": "sha512-wSjavK9yyhaqa4VGO8QcTZJuw5lN7bk3kYscbTt9xHJdudczIY8rQS967eyBsTba1lGrjsN9uKAFAPqPd4RuoA==",
       "requires": {
         "cql-exec-fhir": "^2.1.4",
-        "cql-execution": "^2.4.0"
+        "cql-execution": "^3.0.1"
       }
     },
     "create-ecdh": {
@@ -47628,12 +47634,12 @@
       "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
     },
     "encender": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/encender/-/encender-0.7.0.tgz",
-      "integrity": "sha512-DASkDK6A9Xk+ZUSCmJGOM0KlYbH5D39KBGAKRBe7SXx+cngTrQwPh8vxmz3EXs8D0yYB/xhoVWKA82j1WbJR3g==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/encender/-/encender-0.7.1.tgz",
+      "integrity": "sha512-7w27zgCQ5zIaXdPIPfq/iwlaWgbw+gCPaIOFJsQL313Pf2sYmlDeUH8WHTtMSMVv4m+YpguYMVBFP7kAXw8ClQ==",
       "requires": {
         "@asymmetrik/fhir-json-schema-validator": "^0.9.8",
-        "cql-worker": "^1.1.6",
+        "cql-worker": "^1.1.7",
         "semver": "^6.3.0"
       },
       "dependencies": {
@@ -58749,7 +58755,9 @@
       "version": "9.0.12"
     },
     "immutable": {
-      "version": "4.0.0"
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
+      "integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA=="
     },
     "import-fresh": {
       "version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccsm-cds-dashboard",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "Apache-2.0",
   "homepage": "/",
   "dependencies": {
@@ -34,7 +34,7 @@
     "css-minimizer-webpack-plugin": "^3.2.0",
     "dotenv": "^10.0.0",
     "dotenv-expand": "^5.1.0",
-    "encender": "^0.7.0",
+    "encender": "^0.7.1",
     "eslint": "^8.3.0",
     "eslint-config-react-app": "^7.0.1",
     "eslint-webpack-plugin": "^3.1.1",

--- a/src/smart/SmartPatient.js
+++ b/src/smart/SmartPatient.js
@@ -101,8 +101,8 @@ export function SmartPatient() {
         console.log(e);
       }
 
-      let epTypeStr = process.env?.REACT_APP_CCSM_EPISODEOFCARE_TYPES ?? 'urn:oid:1.2.840.114350.1.13.284.2.7.4.726668.130|2,urn:oid:1.2.840.114350.1.13.284.3.7.4.726668.130|2';
-      
+      let epTypeStr = process.env?.REACT_APP_CCSM_EPISODEOFCARE_TYPES ?? 'urn:oid:1.2.840.114350.1.13.284.3.7.4.726668.130|2';
+
       try {
         await client.request('/EpisodeOfCare?patient=' + pid + '&type=' + epTypeStr).then(async function(ec) {
           await fhirParser(ec);

--- a/src/smart/SmartPatient.js
+++ b/src/smart/SmartPatient.js
@@ -101,7 +101,7 @@ export function SmartPatient() {
         console.log(e);
       }
 
-      let epTypeStr = process.env?.REACT_APP_CCSM_EPISODEOFCARE_TYPES ?? 'urn:oid:1.2.840.114350.1.13.284.3.7.4.726668.130|2';
+      let epTypeStr = process.env?.REACT_APP_CCSM_EPISODEOFCARE_TYPES ?? 'urn:oid:1.2.840.114350.1.13.284.2.7.4.726668.130|2';
 
       try {
         await client.request('/EpisodeOfCare?patient=' + pid + '&type=' + epTypeStr).then(async function(ec) {


### PR DESCRIPTION
This PR fix https://jira.mitre.org/browse/CCSMCDS-98:

What changed:

Reuse the REACT_APP_CCSM_EPISODEOFCARE_TYPES environment variable.
Change the default to nonPROD system

Notes for develoyment:
* For developer: add this to .env file
```
# This is the value for EpisodeOfCare's type search:
## For nonPROD system, use urn:oid:1.2.840.114350.1.13.284.3.7.4.726668.130|2
## For PROD syste, use urn:oid:1.2.840.114350.1.13.284.2.7.4.726668.130|2
REACT_APP_CCSM_EPISODEOFCARE_TYPES='urn:oid:1.2.840.114350.1.13.284.3.7.4.726668.130|2'
```
* For UMMC deployment: remember to add **REACT_APP_CCSM_EPISODEOFCARE_TYPES='urn:oid:1.2.840.114350.1.13.284.3.7.4.726668.130|2'** to server's environment