### PR TITLE
Skip STRIDES translation if patient MRN is not in STRIDES database

### DIFF
--- a/src/hooks/useCds/translate.js
+++ b/src/hooks/useCds/translate.js
@@ -311,7 +311,7 @@ function mapResult(result, loincMapping, testCodeResultMapping) {
 // Strides Data
 //
 function mapStrideResult(patientData, patientDataMap, stridesData) {
-  if (patientDataMap?.Patient == null || patientDataMap.Patient.length === 0 || patientDataMap.DiagnosticReport == null || patientDataMap.DiagnosticReport.length === 0) {
+  if (!patientDataMap || !(patientDataMap.Patient?.length) || !(patientDataMap.DiagnosticReport?.length)) {
     return;
   }
 

--- a/src/hooks/useCds/translate.js
+++ b/src/hooks/useCds/translate.js
@@ -317,11 +317,15 @@ function mapStrideResult(patientData, patientDataMap, stridesData) {
 
   const mrn = patientDataMap.Patient[0].identifier?.find(id =>id.type?.text === ('MRN') || id.type?.text === ('Medical Record Number'))?.value;
 
-  if (!mrn || patientDataMap.DiagnosticReport.length === 0 || !(mrn in stridesData)) {
+  if (!mrn || patientDataMap.DiagnosticReport.length === 0) {
     return;
   }
 
   const stridesPatientData = stridesData[mrn];
+
+  if (!stridesPatientData) {  
+    return;  
+  }  
 
   stridesPatientData.forEach(row => {
     const orderId = row['ORDER_ID'];

--- a/src/hooks/useCds/translate.js
+++ b/src/hooks/useCds/translate.js
@@ -315,9 +315,9 @@ function mapStrideResult(patientData, patientDataMap, stridesData) {
     return;
   }
 
-  const mrn = patientDataMap.Patient[0].identifier?.find(id => id.type?.text === 'MRN')?.value;
+  const mrn = patientDataMap.Patient[0].identifier?.find(id =>id.type?.text === ('MRN') || id.type?.text === ('Medical Record Number'))?.value;
 
-  if (!mrn || patientDataMap.DiagnosticReport.length === 0) {
+  if (!mrn || patientDataMap.DiagnosticReport.length === 0 || !(mrn in stridesData)) {
     return;
   }
 

--- a/src/hooks/useCds/translate.js
+++ b/src/hooks/useCds/translate.js
@@ -311,21 +311,21 @@ function mapResult(result, loincMapping, testCodeResultMapping) {
 // Strides Data
 //
 function mapStrideResult(patientData, patientDataMap, stridesData) {
-  if (patientDataMap?.Patient == null || patientDataMap.Patient.length === 0) {
+  if (patientDataMap?.Patient == null || patientDataMap.Patient.length === 0 || patientDataMap.DiagnosticReport == null || patientDataMap.DiagnosticReport.length === 0) {
     return;
   }
 
   const mrn = patientDataMap.Patient[0].identifier?.find(id =>id.type?.text === ('MRN') || id.type?.text === ('Medical Record Number'))?.value;
 
-  if (!mrn || patientDataMap.DiagnosticReport.length === 0) {
+  if (!mrn) {
     return;
   }
 
   const stridesPatientData = stridesData[mrn];
 
-  if (!stridesPatientData) {  
-    return;  
-  }  
+  if (!stridesPatientData) {
+    return;
+  }
 
   stridesPatientData.forEach(row => {
     const orderId = row['ORDER_ID'];

--- a/src/hooks/useCds/translate.js
+++ b/src/hooks/useCds/translate.js
@@ -315,7 +315,7 @@ function mapStrideResult(patientData, patientDataMap, stridesData) {
     return;
   }
 
-  const mrn = patientDataMap.Patient[0].identifier?.find(id =>id.type?.text === ('MRN') || id.type?.text === ('Medical Record Number'))?.value;
+  const mrn = patientDataMap.Patient[0].identifier?.find(id => id.type?.text === ('MRN') || id.type?.text === ('Medical Record Number'))?.value;
 
   if (!mrn) {
     return;

--- a/test/fixtures/translate/patientData.json
+++ b/test/fixtures/translate/patientData.json
@@ -387,8 +387,8 @@
       "status" : "active",
       "type" : [{
         "coding" : [{
-          "system" : "urn:oid:1.2.840.114350.1.13.88.3.7.2.726668",
-          "code" : "6",
+          "system" : "urn:oid:1.2.840.114350.1.13.284.3.7.4.726668.130",
+          "code" : "2",
           "display" : "PREGNANCY"
         }]
       }],

--- a/test/translate-test.js
+++ b/test/translate-test.js
@@ -34,8 +34,8 @@ describe('translate', () => {
     });
 
     it('should return when Patient does not have MRN', () => {
-      let patientWithoutMRN = patientData.find(pd => pd.resourceType === 'Patient')
-      patientWithoutMRN.identifier = patientWithoutMRN.identifier.filter(id => id.type.text !== 'MRN')
+      let patientWithoutMRN = patientData.find(pd => pd.resourceType === 'Patient');
+      patientWithoutMRN.identifier = patientWithoutMRN.identifier.filter(id => id.type.text !== 'MRN');
       translateResponse(patientData, stridesData);
       expect(patientData.some(resource => resource.resourceType === 'DiagnosticReport' && resource.conclusionCodes?.some(cc => cc.coding.some(coding => coding.display?.includes('STRIDES Code'))))).to.be.false;
     });

--- a/test/translate-test.js
+++ b/test/translate-test.js
@@ -29,8 +29,21 @@ describe('translate', () => {
 
     it('should include strides data', () => {
       translateResponse(patientData, stridesData);
-      expect(patientData.some(resource => resource.resourceType === 'DiagnosticReport' && resource.conclusionCodes?.length > 0)).to.be.true;
+      expect(patientData.some(resource => resource.resourceType === 'DiagnosticReport' && resource.conclusionCodes?.some(cc => cc.coding.some(coding => coding.display?.includes('STRIDES Code'))))).to.be.true;
       expect(patientData.some(resource => resource.resourceType === 'Procedure')).to.be.true;
+    });
+
+    it('should return when Patient does not have MRN', () => {
+      let patientWithoutMRN = patientData.find(pd => pd.resourceType === 'Patient')
+      patientWithoutMRN.identifier = patientWithoutMRN.identifier.filter(id => id.type.text !== 'MRN')
+      translateResponse(patientData, stridesData);
+      expect(patientData.some(resource => resource.resourceType === 'DiagnosticReport' && resource.conclusionCodes?.some(cc => cc.coding.some(coding => coding.display?.includes('STRIDES Code'))))).to.be.false;
+    });
+
+    it('should return when patientData does not have DiagnosticReport', () => {
+      patientData = patientData.filter(pd => pd.resourceType !== 'DiagnosticReport')
+      translateResponse(patientData, stridesData);
+      expect(patientData.some(resource => resource.resourceType === 'DiagnosticReport' && resource.conclusionCodes?.some(cc => cc.coding.some(coding => coding.display?.includes('STRIDES Code'))))).to.be.false;
     });
   });
 


### PR DESCRIPTION
This is in response to a pilot issue that recently came up. The React Dashboard threw an error when running a non-production patient against the version of the code that uses the STRIDES database.

It looks like our translate.js code gracefully skips the STRIDES mapping if the patient does not have an MRN (the case for the Logica patients I have been testing), but if they do have an MRN but it is not in the STRIDES database (the case for the test patients UMMC is testing) then an error is thrown by translate.js line 326.

This does two things:
1) Skips STRIDES translation if patient has MRN that is not in the STRIDES database.
2) Adds "Medical Record Number" as a Patient.identifier.type.text that could qualify as a patient MRN. This is used by the sandbox patients in the [SMART App Launcher](https://launch.smarthealthit.org/).