### PR TITLE
Add System OID for EOC and Strides DiagnosticReport's code

### DIFF
--- a/src/hooks/useCds/translate.js
+++ b/src/hooks/useCds/translate.js
@@ -248,6 +248,12 @@ const snomedPregnancyCare = {
   'display': 'Antenatal care (regime/therapy)'
 };
 
+const loincBiopsyReport = {
+  system: LOINC_URL,
+  code: '65753-6',
+  display: 'Cervix Pathology biopsy report'
+}
+
 /**
  * Translate terminology codings used in Observation
  * To be considered in future use: Translate terminology codings used DiagnosticReport
@@ -352,6 +358,8 @@ function mapStrideResult(patientData, patientDataMap, stridesData) {
     const mappedDiagnosisCC = mapStridesCodeToCC(row, 'IMSDiscreteGoldDiagnosis', STRIDES_DIAG_URI);
 
     if (mappedDiagnosisCC) {
+      diagnosticReport.code.coding.push(loincBiopsyReport);
+
       diagnosticReport.conclusionCodes ||= [];
 
       diagnosticReport.conclusionCodes.push(mappedDiagnosisCC);

--- a/src/hooks/useCds/translate.js
+++ b/src/hooks/useCds/translate.js
@@ -236,9 +236,9 @@ const STRIDES_PROC_URI = 'urn:uuid:273494e4-40f0-4a53-b1a3-2d30c32d76d1';
 
 // EPIC Code System for EpisodeOfCare Type
 const episodeOfCareTypeCodeSystem = [
-  'urn:oid:1.2.840.114350.1.13.284.2.7.4.726668', //PRD
+  'urn:oid:1.2.840.114350.1.13.284.2.7.2.726668', //PRD
   'urn:oid:1.2.840.114350.1.13.284.2.7.4.726668.130', // PRD
-  'urn:oid:1.2.840.114350.1.13.284.3.7.4.726668', // nonPRD
+  'urn:oid:1.2.840.114350.1.13.284.3.7.2.726668', // nonPRD
   'urn:oid:1.2.840.114350.1.13.284.3.7.4.726668.130' // nonPRD
 ];
 

--- a/test/fixtures/translate/patientData.json
+++ b/test/fixtures/translate/patientData.json
@@ -387,7 +387,7 @@
       "status" : "active",
       "type" : [{
         "coding" : [{
-          "system" : "urn:oid:1.2.840.114350.1.13.284.3.7.4.726668",
+          "system" : "urn:oid:1.2.840.114350.1.13.284.3.7.2.726668",
           "code" : "2",
           "display" : "PREGNANCY"
         }]

--- a/test/translate-test.js
+++ b/test/translate-test.js
@@ -31,22 +31,26 @@ describe('translate', () => {
       translateResponse(patientData, stridesData);
       expect(patientData.some(resource => resource.resourceType === 'DiagnosticReport' &&
                               resource.code.coding.some(coding => coding.code === '65753-6' && coding.system === 'http://loinc.org') &&
-                              resource.conclusionCodes?.length > 0)
+                              resource.conclusionCodes?.some(cc => cc.coding.some(coding => coding.system == 'urn:uuid:90915bcf-353c-49e1-b65e-0464798baa77')))
             ).to.be.true;
-      expect(patientData.some(resource => resource.resourceType === 'Procedure')).to.be.true;
+      expect(patientData.some(resource => resource.resourceType === 'Procedure' &&
+                              resource.code.coding.some(coding => coding.system == 'urn:uuid:273494e4-40f0-4a53-b1a3-2d30c32d76d1'))
+            ).to.be.true;
     });
 
     it('should return when Patient does not have MRN', () => {
       let patientWithoutMRN = patientData.find(pd => pd.resourceType === 'Patient');
       patientWithoutMRN.identifier = patientWithoutMRN.identifier.filter(id => id.type.text !== 'MRN');
       translateResponse(patientData, stridesData);
-      expect(patientData.some(resource => resource.resourceType === 'DiagnosticReport' && resource.conclusionCodes?.some(cc => cc.coding.some(coding => coding.display?.includes('STRIDES Code'))))).to.be.false;
+      expect(patientData.some(resource => resource.resourceType === 'DiagnosticReport' &&
+                              resource.code.coding.some(coding => coding.code === '65753-6' && coding.system === 'http://loinc.org'))
+            ).to.be.false;
     });
 
     it('should return when patientData does not have DiagnosticReport', () => {
       patientData = patientData.filter(pd => pd.resourceType !== 'DiagnosticReport')
       translateResponse(patientData, stridesData);
-      expect(patientData.some(resource => resource.resourceType === 'DiagnosticReport' && resource.conclusionCodes?.some(cc => cc.coding.some(coding => coding.display?.includes('STRIDES Code'))))).to.be.false;
+      expect(patientData.some(resource => resource.resourceType === 'DiagnosticReport')).to.be.false;
     });
   });
 

--- a/test/translate-test.js
+++ b/test/translate-test.js
@@ -29,7 +29,10 @@ describe('translate', () => {
 
     it('should include strides data', () => {
       translateResponse(patientData, stridesData);
-      expect(patientData.some(resource => resource.resourceType === 'DiagnosticReport' && resource.conclusionCodes?.length > 0)).to.be.true;
+      expect(patientData.some(resource => resource.resourceType === 'DiagnosticReport' &&
+              resource.code.coding.some(coding => coding.code === '65753-6' && coding.system === 'http://loinc.org') &&
+              resource.conclusionCodes?.length > 0)
+            ).to.be.true;
       expect(patientData.some(resource => resource.resourceType === 'Procedure')).to.be.true;
     });
   });


### PR DESCRIPTION
This PR fixes these issues

1. Add two new EpisodeOfCare System OIDs: 'urn:oid:1.2.840.114350.1.13.284.2.7.2.726668' and ''urn:oid:1.2.840.114350.1.13.284.3.7.2.726668'
2. Add LOINC Biopsy Report coding to Strides mapped DiagnosticReport
3. Fix unit tests.