### PR TITLE
Update string matching for multi-lines in Observation

### DIFF
--- a/src/hooks/useCds/translate.js
+++ b/src/hooks/useCds/translate.js
@@ -314,7 +314,8 @@ function mapResult(result, loincMapping, testCodeResultMapping) {
   );
 
   if (customCodes && !result.valueCodeableConcept && result.valueString) {
-    const mappedCode = customCodes.map.find(cc => cc.text.localeCompare(result.valueString, undefined, { sensitivity: 'base' }) === 0);
+    const firstLine = result.valueString.split("\r\n")[0];
+    const mappedCode = customCodes.map.find(cc => cc.text.localeCompare(firstLine, undefined, { sensitivity: 'base' }) === 0);
 
     if (mappedCode) {
       result.valueCodeableConcept = {

--- a/test/fixtures/translate/patientData.json
+++ b/test/fixtures/translate/patientData.json
@@ -292,18 +292,6 @@
     {
       "resourceType": "Observation",
       "id": "eUrGUNtzxT9id1SHtl3tpacHtu8tHcFVysvIu.pX25U.9uqPJrDlw20BL812chn6B3",
-      "extension": [
-        {
-          "valueString": "Electronically signed by Cynthia A Branch on 6/2/2023 at 0701",
-          "url": "http://open.epic.com/FHIR/StructureDefinition/extension/lab-e-signature"
-        }
-      ],
-      "basedOn": [
-        {
-          "reference": "ServiceRequest/eTIz4TR3sWOWgEbarJolJprh48aYPi5MwR-XpH3m8N0E3",
-          "display": "Pap Smear:"
-        }
-      ],
       "status": "final",
       "category": [
         {
@@ -350,23 +338,8 @@
         "reference": "Patient/e1S83RNdPiAD-yaxd0xvQZA3",
         "display": "Testmit\n Twseven"
       },
-      "encounter": {
-        "reference": "Encounter/ey1VmmdA7Y3EWse0th2Y1qg3",
-        "display": "Office Visit",
-        "identifier": {
-          "use": "usual",
-          "system": "urn:oid:1.2.840.114350.1.13.284.3.7.3.698084.8",
-          "value": "6000065122"
-        }
-      },
       "effectiveDateTime": "2022-12-31T22:02:00Z",
       "issued": "2023-06-02T12:01:10Z",
-      "performer": [
-        {
-          "reference": "Practitioner/egiXoQSv.MetRaicyKpUlSw3",
-          "display": "William P. Daley\n MD"
-        }
-      ],
       "valueString": "Atypical squamous cells of undetermined significance",
       "interpretation": [
         {

--- a/test/translate-test.js
+++ b/test/translate-test.js
@@ -21,6 +21,21 @@ describe('translate', () => {
         resource.valueCodeableConcept?.coding?.some(coding => coding.system === 'http://snomed.info/sct' && coding.code === '441087007')
       )).to.be.true
     });
+
+    it('should add SNOMED CT coding to Observation if valueString has more than one line', () => {
+      const obs = patientData.find(pd => pd.resourceType === 'Observation' && pd.valueString);
+      const expectedString = obs.valueString + "\r\nadditional line";
+      obs.valueString = expectedString
+
+      translateResponse(patientData);
+
+      expect(patientData.some(resource =>
+        resource.resourceType === 'Observation' &&
+        !resource.valueString &&
+        resource.valueCodeableConcept?.text === expectedString &&
+        resource.valueCodeableConcept?.coding?.some(coding => coding.system === 'http://snomed.info/sct' && coding.code === '441087007')
+      )).to.be.true
+    });
   });
 
   describe('maps strides data', () => {


### PR DESCRIPTION
This PR fixes an issue that when Observation.valueString has multiple line, separated by "\r\n", the string matching skipps.

What is changed:
* Update the mapResult to use the first line from valueString.
* Add unit test.
* Remove some redundant data from mocked patientData input for unit testing