### PR TITLE
Use Promise.allSettled versus Promise.all so that all FHIR queries are made before the CDS is applied.

### DIFF
--- a/src/smart/SmartPatient.js
+++ b/src/smart/SmartPatient.js
@@ -55,7 +55,7 @@ export function SmartPatient() {
       );
 
       try {
-        await Promise.all(promises);
+        await Promise.allSettled(promises);
       } catch (e) {
         console.log(e);
       }


### PR DESCRIPTION
I noticed a bug in https://github.com/ccsm-cds-tools/ccsm-cds-dashboard/pull/42 where the CDS was applying and the Dashboard was rendering before the FHIR queries were done being made. As a result, the dashboard was loading with only a subset of the patient data. To fix this, I changed `Promise.all()` to `Promise.allSettled()`, so that if one of the GET requests fails, the code will still wait for the rest of the promises (FHIR calls) to return, before proceeding with applying the CDS.