### PR TITLE
Map Generic HPV LOINC Code

### DIFF
--- a/src/hooks/useCds/translate.js
+++ b/src/hooks/useCds/translate.js
@@ -98,7 +98,7 @@ const testCodeResultMapping = [
     ]
   },
   {
-    testCode: ['71431-1', '77399-4', '77400-0'],
+    testCode: ['82675-0' ,'71431-1', '77399-4', '77400-0'],
     testName: 'HPV',
     map: [
       {
@@ -215,6 +215,10 @@ const stridesCodeMapping = {
 };
 
 const loincMapping = [
+  {
+    oldCode: '49896-4',
+    newCode: '82675-0'
+  },
   {
     oldCode: '61372-9',
     newCode: '77399-4'
@@ -358,6 +362,7 @@ export function translateResponse(patientData, stridesData) {
   const patientDataMap = patientDataToHash(patientData);
 
   patientDataMap.Observation?.forEach(pd => mapResult(pd, loincMapping, testCodeResultMapping));
+  patientDataMap.DiagnosticReport?.forEach(pd => mapResult(pd, loincMapping, testCodeResultMapping));
   patientDataMap.EpisodeOfCare?.forEach(episodeOfCare => mapEpisodeOfCare(episodeOfCare));
 
   if (stridesData && Object.keys(stridesData).length > 0) {
@@ -450,6 +455,8 @@ function mapResult(result, loincMapping, testCodeResultMapping) {
     result.code.coding.some(coding => ts.testCode?.includes(coding.code))
   );
 
+  // Should evaluate to false for DiagnosticReports, skipping the result mapping for these resources. We can add logic to
+  // map string values to codes values within DiagnosticReport.conclusionCode, if we find that this occurs in practice
   if (customCodes && !result.valueCodeableConcept && result.valueString) {
     const firstLine = result.valueString.split("\r\n")[0];
     const mappedCode = customCodes.map.find(cc => cc.text.localeCompare(firstLine, undefined, { sensitivity: 'base' }) === 0);

--- a/test/translate-test.js
+++ b/test/translate-test.js
@@ -36,6 +36,24 @@ describe('translate', () => {
         resource.valueCodeableConcept?.coding?.some(coding => coding.system === 'http://snomed.info/sct' && coding.code === '441087007')
       )).to.be.true
     });
+
+    it('should translate LOINC code from a DiagnosticReport', () => {
+      const dr = patientData.find(pd => pd.resourceType === 'DiagnosticReport');
+      const genericHpvTestCode =
+        {
+          "system": "http://loinc.org",
+          "code": "49896-4"
+        };
+      dr.code.coding = [genericHpvTestCode];
+
+      translateResponse(patientData);
+
+      expect(patientData.some(resource =>
+        resource.resourceType === 'DiagnosticReport' &&
+        resource.code &&
+        resource.code?.coding?.some(coding => coding.system === 'http://loinc.org' && coding.code === '82675-0')
+      )).to.be.true
+    });
   });
 
   describe('maps strides data', () => {


### PR DESCRIPTION
This PR addresses the HPV Result half of [CCSMCDS-131](https://jira.mitre.org/browse/CCSMCDS-131). Through testing with our pilot partner, we found that their old HPV tests were using a generic LOINC code for HPV Presence in Specimen, as opposed to HPV Presence in Cervix. Upon discussing with the pilot partner, we confirmed that these test codes are still meant to represent a cervical HPV test at their health center. This PR allows us to map the more generic HPV test LOINC code to the more specific cervix HPV test LOINC code that our CDS recognizes.

The following is included in this PR:

- Add capability to map DiagnosticReport.code values within translate.js.
- Map generic HPV LOINC code to cervix specific code.
- Add testing to show that DiagnosticReport.code is able to be translated.