### PR TITLE
Remove search for Encounter Diagnosis category category of Condition

### DIFF
--- a/src/smart/SmartPatient.js
+++ b/src/smart/SmartPatient.js
@@ -38,11 +38,7 @@ export function SmartPatient() {
 
       const promises = [];
 
-<<<<<<< HEAD
       promises.push(client.request(`/Condition?patient=${pid}&category=problem-list-item,medical-history`).then(fhirParser));
-=======
-      promises.push(client.request(`/Condition?patient=${pid}&category=encounter-diagnosis,problem-list-item,medical-history&_include=Condition:encounter:Encounter`).then(fhirParser)); // include Encounters referenced by Conditions to avoid a separate API search
->>>>>>> pilot
       promises.push(client.request(`/DiagnosticReport?patient=${pid}&category=http://terminology.hl7.org/CodeSystem/v2-0074|Lab`).then(fhirParser));
       promises.push(client.request(`/Immunization?patient=${pid}&status=completed&vaccine-code=118,137,165,62`).then(fhirParser));
       promises.push(client.request(`/MedicationRequest?patient=${pid}&status=completed`).then(fhirParser));

--- a/src/smart/SmartPatient.js
+++ b/src/smart/SmartPatient.js
@@ -38,7 +38,7 @@ export function SmartPatient() {
 
       const promises = [];
 
-      promises.push(client.request(`/Condition?patient=${pid}&category=encounter-diagnosis,problem-list-item,medical-history&_include=Condition:encounter:Encounter`).then(fhirParser)); // include Encounters referenced by Conditions to avoid a separate API search
+      promises.push(client.request(`/Condition?patient=${pid}&category=problem-list-item,medical-history`).then(fhirParser));
       promises.push(client.request(`/DiagnosticReport?patient=${pid}&category=http://terminology.hl7.org/CodeSystem/v2-0074|Lab`).then(fhirParser));
       promises.push(client.request(`/Immunization?patient=${pid}&status=completed&vaccine-code=118,137,165,62`).then(fhirParser));
       promises.push(client.request(`/MedicationRequest?patient=${pid}&status=completed`).then(fhirParser));

--- a/src/smart/SmartPatient.js
+++ b/src/smart/SmartPatient.js
@@ -38,18 +38,17 @@ export function SmartPatient() {
 
       const promises = [];
 
-      promises.push(client.request(`/Condition?patient=${pid}&category=problems,medical-history`).then(fhirParser)); // Limit Conditions by category. Combine into one search. Check spelling of category names
-      promises.push(client.request(`/DiagnosticReport?patient=${pid}&category=laboratory`).then(fhirParser)); // Filter by lab category, although this may not narrow things down too much.
-      promises.push(client.request(`/Encounter?patient=${pid}`).then(fhirParser)); // Probably don't need all encounters. Could consider narrowing scope ny doing a _include on Condition
-      promises.push(client.request(`/Immunization?patient=${pid}&status=completed`).then(fhirParser)); // Could test to see if we can filter by vaccineCode
-      promises.push(client.request(`/MedicationRequest?patient=${pid}&status=active`).then(fhirParser));
-      promises.push(client.request(`/Procedure?patient=${pid}&category=order,surgery,surgical-history`).then(fhirParser)); // Use codes in search for the three specific types of procedures
+      promises.push(client.request(`/Condition?patient=${pid}&category=encounter-diagnosis,problem-list-item,medical-history&_include=Condition:encounter:Encounter`).then(fhirParser)); // include Encounters referenced by Conditions to avoid a separate API search
+      promises.push(client.request(`/DiagnosticReport?patient=${pid}&category=http://terminology.hl7.org/CodeSystem/v2-0074|Lab`).then(fhirParser));
+      promises.push(client.request(`/Immunization?patient=${pid}&status=completed&vaccine-code=118,137,165,62`).then(fhirParser));
+      promises.push(client.request(`/MedicationRequest?patient=${pid}&status=completed`).then(fhirParser));
+      promises.push(client.request(`/Procedure?patient=${pid}&status=completed&category=http://snomed.info/sct|103693007,http://snomed.info/sct|387713003`).then(fhirParser)); // Search Procedures with category of Diagnostic procedure or Surgical procedure
 
-      const eocType = process.env?.REACT_APP_CCSM_EPISODEOFCARE_TYPES ?? 'urn:id:1.2.840.114350.1.13.284.2.7.2.726668|2';
+      const eocType = process.env?.REACT_APP_CCSM_EPISODEOFCARE_TYPES ?? 'urn:id:1.2.840.114350.1.13.284.2.7.2.726668|2'; // Search Episodes of Care with type of Pregnancy
       promises.push(client.request(`/EpisodeOfCare?patient=${pid}&type=${eocType}`).then(fhirParser));
 
-      promises.push(client.request(`/Observation?patient=${pid}&category=laboratory,obstetrics-gynecology`).then(fhirParser)); // These can be combined into one search, with Observation categories separated by commas.
-      promises.push(client.request(`/Observation?patient=${pid}&category=social-history&code=pregnancy_status`).then(fhirParser));  // Add social history search that specifies pregnancy status. Remove smartdata
+      promises.push(client.request(`/Observation?patient=${pid}&status=final,corrected,amended&category=laboratory,obstetrics-gynecology`).then(fhirParser));
+      promises.push(client.request(`/Observation?patient=${pid}&status=final,corrected,amended&category=social-history&code=http://loinc.org|82810-3`).then(fhirParser)); // Search Observations with code of Pregnancy status
 
       try {
         await Promise.allSettled(promises);


### PR DESCRIPTION
## Issue
[CCSMCDS-130](https://jira.mitre.org/browse/CCSMCDS-130)

## What is Changed
* Remove search for Condition Encounter Diagnosis category.
* Remove search for encounters that were reference by a Condition.

## Explanation
I removed the Search for the Encounter Diagnosis category of Conditions, because these are causing causing repeated Conditions to appear in the UI, without dates, and seem to be slowing down performance. I also removed the `_include` parameter for Encounters, since we no longer will need to fetch the date from the Encounter, as it appears the problem of Conditions missing dates was only the case for Encounter Diagnoses.

## Notes
* I have updated the Condition Encounter Diagnosis row in [APIs in MITRE CDS dashboard app.xlsx](https://mitre.sharepoint.com/:x:/r/sites/CervicalCancerCDS/Shared%20Documents/Pilot%20Task/UMMC%20Pilot/UMMC%20APIs/APIs%20in%20MITRE%20CDS%20dashboard%20app.xlsx?d=w0e9587952d1f441180236e7f8c31da40&csf=1&web=1&e=3iu5Zl) to reflect this change.
* I have requested this be merged into `filter-api-searches`, since it is an amendment of that branch, which is still pending review.