### PR TITLE
Remove everything but barebones Search APIs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -110,17 +110,6 @@
         "webpack-cli": "^5.0.1"
       }
     },
-    "../ccsm-cds-with-tests": {
-      "version": "0.4.17",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "cql-testing": "^2.5.3"
-      },
-      "devDependencies": {
-        "encender": "^0.7.0",
-        "fsh-sushi": "^2.9.0"
-      }
-    },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",
       "license": "Apache-2.0",
@@ -10878,8 +10867,12 @@
       }
     },
     "node_modules/ccsm-cds-with-tests": {
-      "resolved": "../ccsm-cds-with-tests",
-      "link": true
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/ccsm-cds-with-tests/-/ccsm-cds-with-tests-0.4.17.tgz",
+      "integrity": "sha512-vqIuJQCBw1OmhPoYp8Zn0gNGOAXpP0C1uKDxHjNbrpbwFq0XsCYvU32hE+p5snoMpQuSspcZXOmCuu4q1z7GQw==",
+      "dependencies": {
+        "cql-testing": "^2.5.3"
+      }
     },
     "node_modules/chai": {
       "version": "4.3.10",
@@ -11564,6 +11557,18 @@
         "safe-buffer": "~5.1.1"
       }
     },
+    "node_modules/convict": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/convict/-/convict-6.2.4.tgz",
+      "integrity": "sha512-qN60BAwdMVdofckX7AlohVJ2x9UvjTNoKVXCL2LxFk1l7757EJqf1nySdMkPQer0bt8kQ5lQiyZ9/2NvrFBuwQ==",
+      "dependencies": {
+        "lodash.clonedeep": "^4.5.0",
+        "yargs-parser": "^20.2.7"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/cookie": {
       "version": "0.5.0",
       "license": "MIT",
@@ -11636,9 +11641,9 @@
       }
     },
     "node_modules/cql-exec-fhir": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/cql-exec-fhir/-/cql-exec-fhir-2.1.4.tgz",
-      "integrity": "sha512-84Fs2zAyxq6q6mxv9PtLm5zWR+rWv2Gtl0Hgm833kxjzrJBnclMVa2LSY/eqX0/zWAuAsyOLVf+F9Zq89n5rfQ==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/cql-exec-fhir/-/cql-exec-fhir-2.1.5.tgz",
+      "integrity": "sha512-rNseLFJ2IVAtQQqsa4hb6uPFzD1EJBi0Hs4yPZNPqeCuNEUfqvO4dldJ7Edl8IcGMbIrWoKy17dLW5KBKzrSpw==",
       "dependencies": {
         "xml2js": "^0.5.0"
       },
@@ -11647,27 +11652,68 @@
       }
     },
     "node_modules/cql-exec-vsac": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/cql-exec-vsac/-/cql-exec-vsac-2.0.1.tgz",
-      "integrity": "sha512-9eWfMulqxcyFcNv8f3z//q2kc/TGxtgWmfUC9XJEHUXP11HyGkOCFLQKg1bKs73mqUohfxeWsLW/XwfFPG6Rgg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cql-exec-vsac/-/cql-exec-vsac-2.2.0.tgz",
+      "integrity": "sha512-XdzM9jjs4GAm1DqDD0WFmBqC7v+ryFMxqSHjZRnWOpX5xIHXMgqIVtLVWDvEB/Qk0gkn7HVBwKlnLn8PskMR6Q==",
       "dependencies": {
         "debug": "^4.3.4",
-        "mkdirp": "^1.0.4",
-        "node-fetch": "^2.6.7",
-        "xml2js": "^0.5.0"
+        "fs-extra": "^11.2.0",
+        "node-fetch": "^2.7.0",
+        "xml2js": "^0.6.2"
       },
       "peerDependencies": {
         "cql-execution": ">=1.3.0 || ^3.0.0-beta"
       }
     },
-    "node_modules/cql-exec-vsac/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
+    "node_modules/cql-exec-vsac/node_modules/fs-extra": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/cql-exec-vsac/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cql-exec-vsac/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/cql-exec-vsac/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/cql-exec-vsac/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/cql-execution": {
@@ -11678,6 +11724,70 @@
         "@lhncbc/ucum-lhc": "^4.1.3",
         "immutable": "^4.1.0",
         "luxon": "^1.28.1"
+      }
+    },
+    "node_modules/cql-testing": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/cql-testing/-/cql-testing-2.6.1.tgz",
+      "integrity": "sha512-vwARWhcmilUNKa72rcidg09opasclJDHu34ksmtcJ09S6wCl9P2SoonfIkheGcpJqQFjcEWuNzxpnD+B2p5fdg==",
+      "dependencies": {
+        "chai": "^4.3.10",
+        "convict": "^6.2.3",
+        "cql-exec-fhir": "^2.1.5",
+        "cql-exec-vsac": "^2.1.0",
+        "fs-extra": "^11.1.1",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "mocha": "^10.2.0",
+        "semver": "^7.5.4",
+        "uuid": "^9.0.1"
+      },
+      "bin": {
+        "cql-to-elm": "bin/cql2elm.js"
+      },
+      "peerDependencies": {
+        "cql-execution": ">=1.3.0"
+      }
+    },
+    "node_modules/cql-testing/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/cql-testing/node_modules/fs-extra": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/cql-testing/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/cql-testing/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/cql-worker": {
@@ -28452,6 +28562,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "license": "MIT"
@@ -28725,6 +28840,8 @@
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -34734,12 +34851,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
-      "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -38344,7 +38458,9 @@
     },
     "node_modules/yallist": {
       "version": "4.0.0",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/yaml": {
       "version": "1.10.2",
@@ -46191,11 +46307,11 @@
       "version": "2.4.0"
     },
     "ccsm-cds-with-tests": {
-      "version": "file:../ccsm-cds-with-tests",
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/ccsm-cds-with-tests/-/ccsm-cds-with-tests-0.4.17.tgz",
+      "integrity": "sha512-vqIuJQCBw1OmhPoYp8Zn0gNGOAXpP0C1uKDxHjNbrpbwFq0XsCYvU32hE+p5snoMpQuSspcZXOmCuu4q1z7GQw==",
       "requires": {
-        "cql-testing": "^2.5.3",
-        "encender": "^0.7.0",
-        "fsh-sushi": "^2.9.0"
+        "cql-testing": "^2.5.3"
       }
     },
     "chai": {
@@ -46722,6 +46838,15 @@
         "safe-buffer": "~5.1.1"
       }
     },
+    "convict": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/convict/-/convict-6.2.4.tgz",
+      "integrity": "sha512-qN60BAwdMVdofckX7AlohVJ2x9UvjTNoKVXCL2LxFk1l7757EJqf1nySdMkPQer0bt8kQ5lQiyZ9/2NvrFBuwQ==",
+      "requires": {
+        "lodash.clonedeep": "^4.5.0",
+        "yargs-parser": "^20.2.7"
+      }
+    },
     "cookie": {
       "version": "0.5.0"
     },
@@ -46767,26 +46892,60 @@
       }
     },
     "cql-exec-fhir": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/cql-exec-fhir/-/cql-exec-fhir-2.1.4.tgz",
-      "integrity": "sha512-84Fs2zAyxq6q6mxv9PtLm5zWR+rWv2Gtl0Hgm833kxjzrJBnclMVa2LSY/eqX0/zWAuAsyOLVf+F9Zq89n5rfQ==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/cql-exec-fhir/-/cql-exec-fhir-2.1.5.tgz",
+      "integrity": "sha512-rNseLFJ2IVAtQQqsa4hb6uPFzD1EJBi0Hs4yPZNPqeCuNEUfqvO4dldJ7Edl8IcGMbIrWoKy17dLW5KBKzrSpw==",
       "requires": {
         "xml2js": ">=0.5.0"
       }
     },
     "cql-exec-vsac": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/cql-exec-vsac/-/cql-exec-vsac-2.0.1.tgz",
-      "integrity": "sha512-9eWfMulqxcyFcNv8f3z//q2kc/TGxtgWmfUC9XJEHUXP11HyGkOCFLQKg1bKs73mqUohfxeWsLW/XwfFPG6Rgg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cql-exec-vsac/-/cql-exec-vsac-2.2.0.tgz",
+      "integrity": "sha512-XdzM9jjs4GAm1DqDD0WFmBqC7v+ryFMxqSHjZRnWOpX5xIHXMgqIVtLVWDvEB/Qk0gkn7HVBwKlnLn8PskMR6Q==",
       "requires": {
         "debug": "^4.3.4",
-        "mkdirp": "^1.0.4",
-        "node-fetch": "^2.6.7",
+        "fs-extra": "^11.2.0",
+        "node-fetch": "^2.7.0",
         "xml2js": ">=0.5.0"
       },
       "dependencies": {
-        "mkdirp": {
-          "version": "1.0.4"
+        "fs-extra": {
+          "version": "11.2.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+          "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "node-fetch": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+          "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
         }
       }
     },
@@ -46798,6 +46957,53 @@
         "@lhncbc/ucum-lhc": "^4.1.3",
         "immutable": "^4.1.0",
         "luxon": "^1.28.1"
+      }
+    },
+    "cql-testing": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/cql-testing/-/cql-testing-2.6.1.tgz",
+      "integrity": "sha512-vwARWhcmilUNKa72rcidg09opasclJDHu34ksmtcJ09S6wCl9P2SoonfIkheGcpJqQFjcEWuNzxpnD+B2p5fdg==",
+      "requires": {
+        "chai": "^4.3.10",
+        "convict": "^6.2.3",
+        "cql-exec-fhir": "^2.1.5",
+        "cql-exec-vsac": "^2.1.0",
+        "fs-extra": "^11.1.1",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "mocha": "^10.2.0",
+        "semver": "^7.5.4",
+        "uuid": "^9.0.1"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        },
+        "fs-extra": {
+          "version": "11.2.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+          "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        },
+        "uuid": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+        }
       }
     },
     "cql-worker": {
@@ -61127,6 +61333,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
+    },
     "lodash.debounce": {
       "version": "4.0.8"
     },
@@ -61348,6 +61559,8 @@
     },
     "lru-cache": {
       "version": "6.0.0",
+      "optional": true,
+      "peer": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -65592,12 +65805,9 @@
       }
     },
     "semver": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
-      "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
-      "requires": {
-        "lru-cache": "^6.0.0"
-      }
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w=="
     },
     "send": {
       "version": "0.18.0",
@@ -68232,7 +68442,9 @@
       "version": "5.0.8"
     },
     "yallist": {
-      "version": "4.0.0"
+      "version": "4.0.0",
+      "optional": true,
+      "peer": true
     },
     "yaml": {
       "version": "1.10.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "buffer": "^6.0.3",
         "camelcase": "^6.2.1",
         "case-sensitive-paths-webpack-plugin": "^2.4.0",
-        "ccsm-cds-with-tests": "^0.4.15",
+        "ccsm-cds-with-tests": "^0.4.17",
         "chai": "^4.3.10",
         "constants-browserify": "^1.0.0",
         "convert-csv-to-json": "^2.0.0",
@@ -108,6 +108,17 @@
         "@babel/register": "^7.22.15",
         "webpack-bundle-analyzer": "^4.8.0",
         "webpack-cli": "^5.0.1"
+      }
+    },
+    "../ccsm-cds-with-tests": {
+      "version": "0.4.17",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cql-testing": "^2.5.3"
+      },
+      "devDependencies": {
+        "encender": "^0.7.0",
+        "fsh-sushi": "^2.9.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -10867,12 +10878,8 @@
       }
     },
     "node_modules/ccsm-cds-with-tests": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/ccsm-cds-with-tests/-/ccsm-cds-with-tests-0.4.15.tgz",
-      "integrity": "sha512-d0Ap6QK81e9VDvWhaIcDVb9B3jhWh5THf8NMl6kdw6aGzlUJjtAoTIwXGNx/QnaR8s28nTkDxvplQkj5dauAqg==",
-      "dependencies": {
-        "cql-testing": "^2.5.3"
-      }
+      "resolved": "../ccsm-cds-with-tests",
+      "link": true
     },
     "node_modules/chai": {
       "version": "4.3.10",
@@ -11557,18 +11564,6 @@
         "safe-buffer": "~5.1.1"
       }
     },
-    "node_modules/convict": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/convict/-/convict-6.2.4.tgz",
-      "integrity": "sha512-qN60BAwdMVdofckX7AlohVJ2x9UvjTNoKVXCL2LxFk1l7757EJqf1nySdMkPQer0bt8kQ5lQiyZ9/2NvrFBuwQ==",
-      "dependencies": {
-        "lodash.clonedeep": "^4.5.0",
-        "yargs-parser": "^20.2.7"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/cookie": {
       "version": "0.5.0",
       "license": "MIT",
@@ -11683,67 +11678,6 @@
         "@lhncbc/ucum-lhc": "^4.1.3",
         "immutable": "^4.1.0",
         "luxon": "^1.28.1"
-      }
-    },
-    "node_modules/cql-testing": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/cql-testing/-/cql-testing-2.5.3.tgz",
-      "integrity": "sha512-xd63XxKhguClyBlMwc8I8ESaZs/NUjp0yk203ynkeyFV2ncAZ7WzhAwGVEfd9wEc0bxkRrw3noZ/513d1IU+tw==",
-      "dependencies": {
-        "chai": "^4.3.7",
-        "convict": "^6.2.3",
-        "cql-exec-fhir": "^2.1.4",
-        "cql-exec-vsac": "^2.0.1",
-        "eslint": "^8.28.0",
-        "fs-extra": "^11.1.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "mocha": "^10.1.0",
-        "semver": "^7.3.8",
-        "uuid": "^9.0.0"
-      },
-      "bin": {
-        "cql-to-elm": "bin/cql2elm.js"
-      },
-      "peerDependencies": {
-        "cql-execution": ">=1.3.0 || ^3.0.0-beta"
-      }
-    },
-    "node_modules/cql-testing/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-    },
-    "node_modules/cql-testing/node_modules/fs-extra": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
-      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/cql-testing/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/cql-testing/node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/cql-worker": {
@@ -28517,11 +28451,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "node_modules/lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -46262,11 +46191,11 @@
       "version": "2.4.0"
     },
     "ccsm-cds-with-tests": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/ccsm-cds-with-tests/-/ccsm-cds-with-tests-0.4.15.tgz",
-      "integrity": "sha512-d0Ap6QK81e9VDvWhaIcDVb9B3jhWh5THf8NMl6kdw6aGzlUJjtAoTIwXGNx/QnaR8s28nTkDxvplQkj5dauAqg==",
+      "version": "file:../ccsm-cds-with-tests",
       "requires": {
-        "cql-testing": "^2.5.3"
+        "cql-testing": "^2.5.3",
+        "encender": "^0.7.0",
+        "fsh-sushi": "^2.9.0"
       }
     },
     "chai": {
@@ -46793,15 +46722,6 @@
         "safe-buffer": "~5.1.1"
       }
     },
-    "convict": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/convict/-/convict-6.2.4.tgz",
-      "integrity": "sha512-qN60BAwdMVdofckX7AlohVJ2x9UvjTNoKVXCL2LxFk1l7757EJqf1nySdMkPQer0bt8kQ5lQiyZ9/2NvrFBuwQ==",
-      "requires": {
-        "lodash.clonedeep": "^4.5.0",
-        "yargs-parser": "^20.2.7"
-      }
-    },
     "cookie": {
       "version": "0.5.0"
     },
@@ -46878,54 +46798,6 @@
         "@lhncbc/ucum-lhc": "^4.1.3",
         "immutable": "^4.1.0",
         "luxon": "^1.28.1"
-      }
-    },
-    "cql-testing": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/cql-testing/-/cql-testing-2.5.3.tgz",
-      "integrity": "sha512-xd63XxKhguClyBlMwc8I8ESaZs/NUjp0yk203ynkeyFV2ncAZ7WzhAwGVEfd9wEc0bxkRrw3noZ/513d1IU+tw==",
-      "requires": {
-        "chai": "^4.3.7",
-        "convict": "^6.2.3",
-        "cql-exec-fhir": "^2.1.4",
-        "cql-exec-vsac": "^2.0.1",
-        "eslint": "^8.28.0",
-        "fs-extra": "^11.1.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "mocha": "^10.1.0",
-        "semver": "^7.3.8",
-        "uuid": "^9.0.0"
-      },
-      "dependencies": {
-        "argparse": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-        },
-        "fs-extra": {
-          "version": "11.1.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
-          "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
-        "js-yaml": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-          "requires": {
-            "argparse": "^2.0.1"
-          }
-        },
-        "uuid": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
-        }
       }
     },
     "cql-worker": {
@@ -61254,11 +61126,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
     "lodash.debounce": {
       "version": "4.0.8"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "buffer": "^6.0.3",
     "camelcase": "^6.2.1",
     "case-sensitive-paths-webpack-plugin": "^2.4.0",
-    "ccsm-cds-with-tests": "^0.4.15",
+    "ccsm-cds-with-tests": "^0.4.17",
     "chai": "^4.3.10",
     "constants-browserify": "^1.0.0",
     "convert-csv-to-json": "^2.0.0",

--- a/src/hooks/useCds/index.js
+++ b/src/hooks/useCds/index.js
@@ -61,10 +61,18 @@ const applyCds = async function(patientData, setOutput, setIsLoadingCdsData, isT
     const WorkerFactory = () => {
       return new Worker(new URL('../../../node_modules/cql-worker/src/cql.worker.js', import.meta.url))
     };
+    
+    // TODO: Move cqlParameters to a separate file within this directory and import them into this file
+    const cqlParameters = {
+      HrHPVLookbackDate: '2017-04-04',
+      CervicalCytologyLookbackDate : '2017-04-04',
+    };
+
     const aux = {
       elmJsonDependencies,
       valueSetJson,
       WorkerFactory,
+      cqlParameters
     };
 
     const [CarePlan, RequestGroup, ...otherResources] = await applyPlan(planDefinition, patientReference, resolver, aux);

--- a/src/smart/SmartPatient.js
+++ b/src/smart/SmartPatient.js
@@ -38,18 +38,17 @@ export function SmartPatient() {
 
       const promises = [];
 
-      promises.push(client.request(`/Condition?patient=${pid}&category=problems,medical-history`).then(fhirParser)); // Limit Conditions by category. Combine into one search. Check spelling of category names
-      promises.push(client.request(`/DiagnosticReport?patient=${pid}&category=laboratory`).then(fhirParser)); // Filter by lab category, although this may not narrow things down too much.
-      promises.push(client.request(`/Encounter?patient=${pid}`).then(fhirParser)); // Probably don't need all encounters. Could consider narrowing scope ny doing a _include on Condition
-      promises.push(client.request(`/Immunization?patient=${pid}&status=completed`).then(fhirParser)); // Could test to see if we can filter by vaccineCode
-      promises.push(client.request(`/MedicationRequest?patient=${pid}&status=active`).then(fhirParser));
-      promises.push(client.request(`/Procedure?patient=${pid}&category=order,surgery,surgical-history`).then(fhirParser)); // Use codes in search for the three specific types of procedures
+      promises.push(client.request(`/Condition?patient=${pid}&category=encounter-diagnosis,problem-list-item,medical-history&_include=Condition:encounter:Encounter`).then(fhirParser)); // include Encounters referenced by Conditions to avoid a separate API search
+      promises.push(client.request(`/DiagnosticReport?patient=${pid}&category=http://terminology.hl7.org/CodeSystem/v2-0074|Lab`).then(fhirParser));
+      promises.push(client.request(`/Immunization?patient=${pid}&status=completed&vaccine-code=118,137,165,62`).then(fhirParser));
+      promises.push(client.request(`/MedicationRequest?patient=${pid}&status=completed`).then(fhirParser));
+      promises.push(client.request(`/Procedure?patient=${pid}&status=completed&category=http://snomed.info/sct|103693007,http://snomed.info/sct|387713003`).then(fhirParser)); // Search Procedures with category of Diagnostic procedure or Surgical procedure
 
-      const eocType = process.env?.REACT_APP_CCSM_EPISODEOFCARE_TYPES ?? 'urn:id:1.2.840.114350.1.13.284.2.7.2.726668|2';
+      const eocType = process.env?.REACT_APP_CCSM_EPISODEOFCARE_TYPES ?? 'urn:id:1.2.840.114350.1.13.284.2.7.2.726668|2'; // Search Episodes of Care with type of Pregnancy
       promises.push(client.request(`/EpisodeOfCare?patient=${pid}&type=${eocType}`).then(fhirParser));
 
-      promises.push(client.request(`/Observation?patient=${pid}&category=laboratory,obstetrics-gynecology`).then(fhirParser)); // These can be combined into one search, with Observation categories separated by commas.
-      promises.push(client.request(`/Observation?patient=${pid}&category=social-history&code=pregnancy_status`).then(fhirParser));  // Add social history search that specifies pregnancy status. Remove smartdata
+      promises.push(client.request(`/Observation?patient=${pid}&status=final,corrected,amended&category=laboratory,obstetrics-gynecology`).then(fhirParser));
+      promises.push(client.request(`/Observation?patient=${pid}&status=final,corrected,amended&category=social-history&code=http://loinc.org|82810-3`).then(fhirParser)); // Search Observations with code of Pregnancy status
 
       try {
         await Promise.allSettled(promises);

--- a/src/smart/SmartPatient.js
+++ b/src/smart/SmartPatient.js
@@ -38,17 +38,9 @@ export function SmartPatient() {
 
       const promises = [];
 
-      promises.push(client.request(`/Condition?patient=${pid}&category=encounter-diagnosis,problem-list-item,medical-history&_include=Condition:encounter:Encounter`).then(fhirParser)); // include Encounters referenced by Conditions to avoid a separate API search
       promises.push(client.request(`/DiagnosticReport?patient=${pid}&category=http://terminology.hl7.org/CodeSystem/v2-0074|Lab`).then(fhirParser));
-      promises.push(client.request(`/Immunization?patient=${pid}&status=completed&vaccine-code=118,137,165,62`).then(fhirParser));
-      promises.push(client.request(`/MedicationRequest?patient=${pid}&status=completed`).then(fhirParser));
+      promises.push(client.request(`/Observation?patient=${pid}&status=final,corrected,amended&category=laboratory`).then(fhirParser));
       promises.push(client.request(`/Procedure?patient=${pid}&status=completed&category=http://snomed.info/sct|103693007,http://snomed.info/sct|387713003`).then(fhirParser)); // Search Procedures with category of Diagnostic procedure or Surgical procedure
-
-      const eocType = process.env?.REACT_APP_CCSM_EPISODEOFCARE_TYPES ?? 'urn:id:1.2.840.114350.1.13.284.2.7.2.726668|2'; // Search Episodes of Care with type of Pregnancy
-      promises.push(client.request(`/EpisodeOfCare?patient=${pid}&type=${eocType}`).then(fhirParser));
-
-      promises.push(client.request(`/Observation?patient=${pid}&status=final,corrected,amended&category=laboratory,obstetrics-gynecology`).then(fhirParser));
-      promises.push(client.request(`/Observation?patient=${pid}&status=final,corrected,amended&category=social-history&code=http://loinc.org|82810-3`).then(fhirParser)); // Search Observations with code of Pregnancy status
 
       try {
         await Promise.allSettled(promises);


### PR DESCRIPTION
I'm opening a draft PR as a reminder that an official PR should be added for commit https://github.com/ccsm-cds-tools/ccsm-cds-dashboard/commit/85a2e42b69621debfa32a29b1f772ff09a7275f6 to address [CCSMCDS-174](https://jira.mitre.org/browse/CCSMCDS-174).

Before opening that official PR, I would like to merge the three currently open PRs that relate to the Search APIs, so that we do have a history that we can go back to when we eventually want to restore some of the search queries that would be eliminated by this change. I would also like to hear feedback from our pilot site about whether our CDS is functional using just the APIs searches left in this commit.