### PR TITLE
Ccsmcds 132 lookback disclaimer

### DIFF
--- a/src/features/PatientHistory/HistoryGroup/index.js
+++ b/src/features/PatientHistory/HistoryGroup/index.js
@@ -3,6 +3,7 @@ import SortableTable from 'components/SortableTable';
 import ViewDataDialog from 'components/ViewDataDialog';
 import HistoryGroupFooter from './HistoryGroupFooter.js';
 import HistoryGroupModals from './HistoryGroupModals.js';
+import IconTooltip from 'components/IconTooltip';
 
 import './styles.scss';
 
@@ -15,6 +16,7 @@ function HistoryGroup(props) {
         filled='',
         empty=''
       },
+      disclaimer,
       tables=[]
     }, 
     tableData,
@@ -42,7 +44,8 @@ function HistoryGroup(props) {
 
   return (
     <div className="history-group">
-      <h2>{title}</h2>
+      <h2>{title}      { disclaimer ? <IconTooltip text={disclaimer}></IconTooltip> : null} </h2>
+
       <HistoryGroupHeading headingText={noHistory ? empty : filled} />
       {
         Object.entries(tableData).map((data,idx) => {

--- a/src/smart/smart.config.js
+++ b/src/smart/smart.config.js
@@ -7,6 +7,7 @@ export const config = {
         filled: '',
         empty: 'No results found'
       },
+      disclaimer: 'Histology and cytology results from before April 23, 2017 may not be available. The CDS will only compute recommendations based on the history shown.',
       tables: [
         {
           name: 'diagnosticReports',
@@ -41,6 +42,7 @@ export const config = {
         filled: 'Includes medical conditions, procedures, and medications that change screening risk',
         empty: 'No relevant history found'
       },
+      disclaimer: '',
       tables: [
         {
           name: 'conditions',
@@ -130,6 +132,7 @@ export const config = {
         filled: '',
         empty: 'No vaccinations found'
       },
+      disclaimer: 'Vaccination history is shown for reference only and is NOT used by CDS to compute recommendations.',
       tables: [
         {
           name: 'immunizations',

--- a/src/test/fhir/test.config.js
+++ b/src/test/fhir/test.config.js
@@ -7,7 +7,7 @@ export const config = {
         filled: '',
         empty: 'No results found'
       },
-      disclaimer: 'No disclaimer',
+      disclaimer: null,
       tables: [
         {
           name: 'diagnosticReports',
@@ -46,7 +46,7 @@ export const config = {
         filled: 'Includes medical conditions, procedures, and medications that change screening risk',
         empty: 'No relevant history found'
       },
-      disclaimer: 'No disclaimer',
+      disclaimer: null,
       tables: [
         {
           name: 'conditions',
@@ -148,7 +148,7 @@ export const config = {
         filled: '',
         empty: 'No vaccinations found'
       },
-      disclaimer: 'No disclaimer',
+      disclaimer: null,
       tables: [
         {
           name: 'immunizations',

--- a/src/test/fhir/test.config.js
+++ b/src/test/fhir/test.config.js
@@ -7,6 +7,7 @@ export const config = {
         filled: '',
         empty: 'No results found'
       },
+      disclaimer: 'No disclaimer',
       tables: [
         {
           name: 'diagnosticReports',
@@ -45,6 +46,7 @@ export const config = {
         filled: 'Includes medical conditions, procedures, and medications that change screening risk',
         empty: 'No relevant history found'
       },
+      disclaimer: 'No disclaimer',
       tables: [
         {
           name: 'conditions',
@@ -146,6 +148,7 @@ export const config = {
         filled: '',
         empty: 'No vaccinations found'
       },
+      disclaimer: 'No disclaimer',
       tables: [
         {
           name: 'immunizations',


### PR DESCRIPTION
Adds disclaimer text to the patient history tables.
Text provided by Carolann Risley. 
Empty disclaimer text added to test/fhir data - no icon should appear if disclaimer is null/empty.
Ideally this should be moved to a configuration file so it may be set for different sites without needing to edit code.

