### PR TITLE
Barebones Search APIs

### DIFF
--- a/src/smart/SmartPatient.js
+++ b/src/smart/SmartPatient.js
@@ -38,17 +38,9 @@ export function SmartPatient() {
 
       const promises = [];
 
-      promises.push(client.request(`/Condition?patient=${pid}&category=problem-list-item,medical-history`).then(fhirParser));
       promises.push(client.request(`/DiagnosticReport?patient=${pid}&category=http://terminology.hl7.org/CodeSystem/v2-0074|Lab`).then(fhirParser));
-      promises.push(client.request(`/Immunization?patient=${pid}&status=completed&vaccine-code=118,137,165,62`).then(fhirParser));
-      promises.push(client.request(`/MedicationRequest?patient=${pid}&status=completed`).then(fhirParser));
+      promises.push(client.request(`/Observation?patient=${pid}&status=final,corrected,amended&category=laboratory`).then(fhirParser));
       promises.push(client.request(`/Procedure?patient=${pid}&status=completed&category=http://snomed.info/sct|103693007,http://snomed.info/sct|387713003`).then(fhirParser)); // Search Procedures with category of Diagnostic procedure or Surgical procedure
-
-      const eocType = process.env?.REACT_APP_CCSM_EPISODEOFCARE_TYPES ?? 'urn:id:1.2.840.114350.1.13.284.2.7.2.726668|2'; // Search Episodes of Care with type of Pregnancy
-      promises.push(client.request(`/EpisodeOfCare?patient=${pid}&type=${eocType}`).then(fhirParser));
-
-      promises.push(client.request(`/Observation?patient=${pid}&status=final,corrected,amended&category=laboratory,obstetrics-gynecology`).then(fhirParser));
-      promises.push(client.request(`/Observation?patient=${pid}&status=final,corrected,amended&category=social-history&code=http://loinc.org|82810-3`).then(fhirParser)); // Search Observations with code of Pregnancy status
 
       try {
         await Promise.allSettled(promises);

--- a/src/smart/SmartPatient.js
+++ b/src/smart/SmartPatient.js
@@ -38,9 +38,22 @@ export function SmartPatient() {
 
       const promises = [];
 
+      // NOTE: Certain API Searches have been commented out, in favor of performance, so that CDS can process only the data critical to making a recommendation.
+      // Data elements obtained from commented out API Searches can be supplemented in the meantime via the user toggle switches.
+      // TODO: Restore commented out API Searches once performance issues have been addressed
+
+      // promises.push(client.request(`/Condition?patient=${pid}&category=problem-list-item,medical-history`).then(fhirParser));
       promises.push(client.request(`/DiagnosticReport?patient=${pid}&category=http://terminology.hl7.org/CodeSystem/v2-0074|Lab`).then(fhirParser));
-      promises.push(client.request(`/Observation?patient=${pid}&status=final,corrected,amended&category=laboratory`).then(fhirParser));
+      // promises.push(client.request(`/Immunization?patient=${pid}&status=completed&vaccine-code=118,137,165,62`).then(fhirParser));
+      // promises.push(client.request(`/MedicationRequest?patient=${pid}&status=completed`).then(fhirParser));
       promises.push(client.request(`/Procedure?patient=${pid}&status=completed&category=http://snomed.info/sct|103693007,http://snomed.info/sct|387713003`).then(fhirParser)); // Search Procedures with category of Diagnostic procedure or Surgical procedure
+
+      // const eocType = process.env?.REACT_APP_CCSM_EPISODEOFCARE_TYPES ?? 'urn:id:1.2.840.114350.1.13.284.2.7.2.726668|2'; // Search Episodes of Care with type of Pregnancy
+      // promises.push(client.request(`/EpisodeOfCare?patient=${pid}&type=${eocType}`).then(fhirParser));
+
+      // promises.push(client.request(`/Observation?patient=${pid}&status=final,corrected,amended&category=laboratory,obstetrics-gynecology`).then(fhirParser));
+      // promises.push(client.request(`/Observation?patient=${pid}&status=final,corrected,amended&category=social-history&code=http://loinc.org|82810-3`).then(fhirParser)); // Search Observations with code of Pregnancy status
+      promises.push(client.request(`/Observation?patient=${pid}&status=final,corrected,amended&category=laboratory`).then(fhirParser));
 
       try {
         await Promise.allSettled(promises);


### PR DESCRIPTION
This PR addresses [CCSMCDS-174](https://jira.mitre.org/browse/CCSMCDS-174). This functionality formerly lived in the [release-pilot_v1.26.3](https://github.com/ccsm-cds-tools/ccsm-cds-dashboard/tree/release-pilot_v1.26.3) branch, and was sent to our pilot partner via a quickfix in release: [pilot_v1.26.5](https://github.com/ccsm-cds-tools/ccsm-cds-dashboard/releases/tag/pilot_v1.26.5). That being said, the functionality was never merged to our `pilot` branch. At the time, I had opened a Draft PR from the [release-pilot_v1.26.3](https://github.com/ccsm-cds-tools/ccsm-cds-dashboard/tree/release-pilot_v1.26.3) branch, as a reminder to merge this functionality, along with a few other quickfixes from that code release, into the pilot branch. That Draft PR can be seen here: https://github.com/ccsm-cds-tools/ccsm-cds-dashboard/pull/52. The other commits from that PR have already been merged into `pilot` through separate PRs. This PR addresses the final commit that had not yet been merged into the `pilot` branch.

For this PR, I:
- Used `git cherry-pick` to pull commit [85a2e42](https://github.com/ccsm-cds-tools/ccsm-cds-dashboard/pull/52/commits/85a2e42b69621debfa32a29b1f772ff09a7275f6) into its own branch.
- Added a commit to restore the removed APIs, keeping them as commented out lines of code. This way, they can be restored later, once performance is addressed.