### PR TITLE
Bump ccsm-cds-with-tests to versoin 0.4.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "buffer": "^6.0.3",
         "camelcase": "^6.2.1",
         "case-sensitive-paths-webpack-plugin": "^2.4.0",
-        "ccsm-cds-with-tests": "^0.4.17",
+        "ccsm-cds-with-tests": "^0.4.18",
         "chai": "^4.3.10",
         "constants-browserify": "^1.0.0",
         "convert-csv-to-json": "^2.0.0",
@@ -10867,9 +10867,9 @@
       }
     },
     "node_modules/ccsm-cds-with-tests": {
-      "version": "0.4.17",
-      "resolved": "https://registry.npmjs.org/ccsm-cds-with-tests/-/ccsm-cds-with-tests-0.4.17.tgz",
-      "integrity": "sha512-vqIuJQCBw1OmhPoYp8Zn0gNGOAXpP0C1uKDxHjNbrpbwFq0XsCYvU32hE+p5snoMpQuSspcZXOmCuu4q1z7GQw==",
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/ccsm-cds-with-tests/-/ccsm-cds-with-tests-0.4.18.tgz",
+      "integrity": "sha512-jhGCAWb/aKlG5rO/7qOj2OKVjGnCo6H5R3iQdQ9KiYyvYbgRKolIy6d5pHT7LAvw3KTDPXNaQwkxj5McYWKY0A==",
       "dependencies": {
         "cql-testing": "^2.5.3"
       }
@@ -46307,9 +46307,9 @@
       "version": "2.4.0"
     },
     "ccsm-cds-with-tests": {
-      "version": "0.4.17",
-      "resolved": "https://registry.npmjs.org/ccsm-cds-with-tests/-/ccsm-cds-with-tests-0.4.17.tgz",
-      "integrity": "sha512-vqIuJQCBw1OmhPoYp8Zn0gNGOAXpP0C1uKDxHjNbrpbwFq0XsCYvU32hE+p5snoMpQuSspcZXOmCuu4q1z7GQw==",
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/ccsm-cds-with-tests/-/ccsm-cds-with-tests-0.4.18.tgz",
+      "integrity": "sha512-jhGCAWb/aKlG5rO/7qOj2OKVjGnCo6H5R3iQdQ9KiYyvYbgRKolIy6d5pHT7LAvw3KTDPXNaQwkxj5McYWKY0A==",
       "requires": {
         "cql-testing": "^2.5.3"
       }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "buffer": "^6.0.3",
     "camelcase": "^6.2.1",
     "case-sensitive-paths-webpack-plugin": "^2.4.0",
-    "ccsm-cds-with-tests": "^0.4.17",
+    "ccsm-cds-with-tests": "^0.4.18",
     "chai": "^4.3.10",
     "constants-browserify": "^1.0.0",
     "convert-csv-to-json": "^2.0.0",


### PR DESCRIPTION
[Bump ccsm-cds-with-tests to version 0.4.18](https://github.com/ccsm-cds-tools/ccsm-cds-dashboard/commit/fecc579c6aab076dafca50a9bca6f677254f1205). This allows the Dashboard to include the most recent PR in ccsm-cds-with-tests to Update recommendation text relative to latest test #140 (https://github.com/ccsm-cds-tools/ccsm-cds-with-tests/pull/140).