### PR TITLE
V0.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccsm-cds-dashboard",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ccsm-cds-dashboard",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccsm-cds-dashboard",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "license": "Apache-2.0",
   "homepage": "/",
   "dependencies": {


### PR DESCRIPTION
# pilot_v1.26.6

- Remove search for Encounter Diagnosis category category of Condition #51
- Ccsmcds 132 lookback disclaimer #53
- Reduce patient info to dob,age,mrn,pregnant #54
- Update testing history disclaimer to include 2-19-2018 cytology date. #55
- Barebones Search APIs #56
- Bump ccsm-cds-with-tests to versoin 0.4.18 #57
- Encender Performant #58
- Add memoize-to-fhir-object branch of cql-exec-fhir as a dependency #59