### PR TITLE
Add 500ms timeout to let React draw spinner before starting CDS calcu…

### DIFF
--- a/src/hooks/useCds/index.js
+++ b/src/hooks/useCds/index.js
@@ -37,7 +37,7 @@ export const useCds = (patientData, toggleStatus) => {
     console.timeEnd('Translate FHIR Data');
     console.log('patientData after translation: ', patientData);
 
-    applyCds(patientData, setOutput, setIsLoadingCdsData, toggleStatus.isToggleChanged, isPregnant, setIsPreganant);
+   window.setTimeout(()=> {applyCds(patientData, setOutput, setIsLoadingCdsData, toggleStatus.isToggleChanged, isPregnant, setIsPreganant);},500);
   }, [patientData, toggleStatus, isPregnant]);
 
   return {output, isLoadingCdsData};


### PR DESCRIPTION
Add a 500ms timeout to applyCds - this gives React a chance to update the UI and show the spinner before CDS computation sucks up 100% of the main thread. This gives time for the toggle switches' CSS transition animation to complete.
