### PR TITLE
Ccsmcds 143 align columns

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -61,3 +61,14 @@ $body-bg: #fff;
   top:0;
   z-index:100;
 }
+
+/* fix the width of the date-* and view columns in the tables */
+table tr th:nth-last-child(-n +2) {
+  width:11em;
+  max-width:11em;
+}
+  
+table tr th:last-child {
+  width:7em;
+  max-width:7em;
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -63,12 +63,12 @@ $body-bg: #fff;
 }
 
 /* fix the width of the date-* and view columns in the tables */
-table tr th:nth-last-child(-n +2) {
+table.sortable.table tr th:nth-last-child(-n +2) {
   width:11em;
   max-width:11em;
 }
   
-table tr th:last-child {
+table.sortable.table tr th:last-child {
   width:7em;
   max-width:7em;
 }


### PR DESCRIPTION
Add CSS to fix the widths of the date and action columns in the patient history tables. This keeps these columns lined up visually across the 4 tables.
View sample patients with procedures and conditions and verify that the date and action columns are visually aligned across all three tables. 