### PR TITLE
Update cql-exec-fhir dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11643,7 +11643,7 @@
     },
     "node_modules/cql-exec-fhir": {
       "version": "2.1.5",
-      "resolved": "git+ssh://git@github.com/ccsm-cds-tools/cql-exec-fhir.git#4c611792741a801781ce5a1eeb33705f86a44ef2",
+      "resolved": "git+ssh://git@github.com/ccsm-cds-tools/cql-exec-fhir.git#d6188beea6e17163943a17b2a592b57a780196de",
       "dependencies": {
         "xml2js": "^0.5.0"
       },
@@ -46883,7 +46883,7 @@
       }
     },
     "cql-exec-fhir": {
-      "version": "git+ssh://git@github.com/ccsm-cds-tools/cql-exec-fhir.git#4c611792741a801781ce5a1eeb33705f86a44ef2",
+      "version": "git+ssh://git@github.com/ccsm-cds-tools/cql-exec-fhir.git#d6188beea6e17163943a17b2a592b57a780196de",
       "from": "cql-exec-fhir@github:ccsm-cds-tools/cql-exec-fhir#memoize-to-fhir-object",
       "requires": {
         "xml2js": ">=0.5.0"


### PR DESCRIPTION
Update `cql-exec-fhir` dependency to reflect two latest pull requests merged into its `memoize-to-fhir-object` branch.

This updates the commit hash for `cql-exec-fhir` in the `package-lock.json` file, so that new installs will pull down the latest version of the `memoize-to-fhir-object` branch, that includes the following two PRs:

1. [Improve performance by only using 3 of 4 arguments to toFHIRObject](https://github.com/ccsm-cds-tools/cql-exec-fhir/pull/1)
2. [Add memoization to get(field) method for FHIRObject](https://github.com/ccsm-cds-tools/cql-exec-fhir/pull/2)