### PR TITLE
Eliminate duplicate cql execution

### DIFF
--- a/src/features/Dashboard/index.js
+++ b/src/features/Dashboard/index.js
@@ -17,6 +17,7 @@ function Dashboard(props) {
     },
     config={},
     setPatientData=()=>{},
+    toggleStatus,
     onToggleStatusChange
   } = props;
 
@@ -36,6 +37,7 @@ function Dashboard(props) {
         <Col xl={6}>
           <DecisionAids
             input={decisionAids}
+            toggleStatus={toggleStatus}
             onToggleStatusChange={onToggleStatusChange}
           />
         </Col>

--- a/src/features/DecisionAids/Recommendations/index.js
+++ b/src/features/DecisionAids/Recommendations/index.js
@@ -19,6 +19,7 @@ function Recommendations(props) {
       riskTable={},
       isCdsApplied
     },
+    toggleStatus, 
     onToggleStatusChange
   } = props;
 
@@ -43,7 +44,7 @@ function Recommendations(props) {
 
   return (
     <div>
-      <SpecialConsiderations onToggleStatusChange={onToggleStatusChange} />
+      <SpecialConsiderations toggleStatus={toggleStatus} onToggleStatusChange={onToggleStatusChange} />
       <Card>
         <Card.Header>Screening and Management Recommendation</Card.Header>
         <Card.Body>

--- a/src/features/DecisionAids/index.js
+++ b/src/features/DecisionAids/index.js
@@ -9,6 +9,7 @@ import './style.scss';
 function DecisionAids(props) {
   const {
     input,
+    toggleStatus,
     onToggleStatusChange
   } = props;
   const { errors=[] } = input;
@@ -19,7 +20,7 @@ function DecisionAids(props) {
       <h2 className="visually-hidden">Decision Aids</h2>
       <Tabs defaultActiveKey={'recs'} className='mb-3'>
         <Tab eventKey={'recs'} title={'Recommendations'}>
-          <Recommendations input={input} onToggleStatusChange={onToggleStatusChange} />
+          <Recommendations input={input} toggleStatus={toggleStatus} onToggleStatusChange={onToggleStatusChange} />
         </Tab>
         <Tab eventKey={'refs'} title={'References'} disabled={errorsExist}>
           <References input={input} />

--- a/src/features/SpecialConsiderations/index.js
+++ b/src/features/SpecialConsiderations/index.js
@@ -7,41 +7,31 @@ import './style.scss';
 
 function SpecialConsiderations(props) {
   let {
+    toggleStatus,
     onToggleStatusChange
   } = props;
 
 
   const [show, setShow] = useState(false);
-  const [toggleStatus, setToggleStatus] = useState({
-    isImmunosuppressed: false,
-    isPregnant: false,
-    isPregnantConcerned: false,
-    isSymptomatic: false,
-    isToggleChanged: false
-  });
-
-  useEffect(() => {
-    onToggleStatusChange(toggleStatus);
-  }, [toggleStatus, onToggleStatusChange]);
 
   const toggleNote = () => {
     setShow(!show);
   }
 
   const handleImmunosuppressedChange = (event) => {
-    setToggleStatus({ ...toggleStatus, isImmunosuppressed: event.target.checked, isToggleChanged: true });
+    onToggleStatusChange({ ...toggleStatus, isImmunosuppressed: event.target.checked, isToggleChanged: true });
   };
 
   const handlePregnantChange = (event) => {
-    setToggleStatus({ ...toggleStatus, isPregnant: event.target.checked, isToggleChanged: true });
+    onToggleStatusChange({ ...toggleStatus, isPregnant: event.target.checked, isToggleChanged: true });
   };
 
   const handlePregnantConcernedChange = (event) => {
-    setToggleStatus({ ...toggleStatus, isPregnantConcerned: event.target.checked, isToggleChanged: true });
+    onToggleStatusChange({ ...toggleStatus, isPregnantConcerned: event.target.checked, isToggleChanged: true });
   };
 
   const handleSymptomaticChange = (event) => {
-    setToggleStatus({ ...toggleStatus, isSymptomatic: event.target.checked, isToggleChanged: true });
+    onToggleStatusChange({ ...toggleStatus, isSymptomatic: event.target.checked, isToggleChanged: true });
   };
 
 

--- a/src/smart/SmartPatient.js
+++ b/src/smart/SmartPatient.js
@@ -106,6 +106,7 @@ export function SmartPatient() {
           input={dashboardInput}
           config={config}
           setPatientData={setPatientData}
+          toggleStatus={toggleStatus}
           onToggleStatusChange={setToggleStatus}
         />
         </div>

--- a/src/test/fhir/TestPatient.js
+++ b/src/test/fhir/TestPatient.js
@@ -47,6 +47,7 @@ export function TestPatient() {
           input={dashboardInput} 
           config={config} 
           setPatientData={setPatientData}
+          toggleStatus={toggleStatus}
           onToggleStatusChange={setToggleStatus}
         />
       </div>


### PR DESCRIPTION
This is a cherry-picked branch from remove-duplicate-cql-execution, which included some experimental features. 
This is updated to be just the fixes to the toggle switches to avoid a re-compute of the CQL. 
@birick1 created this branch to prevent the Dashboard from firing CDS twice. This addresses the issue described in [CCSMCDS-215](https://jira.mitre.org/browse/CCSMCDS-215).

This PR would negate the need for #65 