### PR TITLE
Restore CQL Worker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "css-minimizer-webpack-plugin": "^3.2.0",
         "dotenv": "^10.0.0",
         "dotenv-expand": "^5.1.0",
-        "encender": "github:ccsm-cds-tools/encender#cql-execution",
+        "encender": "github:ccsm-cds-tools/encender#add_cql_worker",
         "eslint": "^8.3.0",
         "eslint-config-react-app": "^7.0.1",
         "eslint-webpack-plugin": "^3.1.1",
@@ -11790,6 +11790,15 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/cql-worker": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/cql-worker/-/cql-worker-1.1.8.tgz",
+      "integrity": "sha512-Gk6uSb5pGzWVRuFjTMf5pL+tkfHXfAHoyndoOo8440FwB0Zno9WFY+aPmnKBsv6UD1p2DvSMpQqK4P6LZ5f67g==",
+      "dependencies": {
+        "cql-exec-fhir": "^2.1.4",
+        "cql-execution": "^3.0.1"
+      }
+    },
     "node_modules/create-ecdh": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
@@ -12829,11 +12838,10 @@
     },
     "node_modules/encender": {
       "version": "0.7.1",
-      "resolved": "git+ssh://git@github.com/ccsm-cds-tools/encender.git#8a3903cb282a45c46b5d12a96d24a23a052067f3",
+      "resolved": "git+ssh://git@github.com/ccsm-cds-tools/encender.git#38c091b061a4d8ba33b60ffadfa7fc5831bc55e2",
       "dependencies": {
         "@asymmetrik/fhir-json-schema-validator": "^0.9.8",
-        "cql-exec-fhir": "2.1.5",
-        "cql-execution": "^3.0.1",
+        "cql-worker": "1.1.8",
         "semver": "^6.3.0"
       }
     },
@@ -46996,6 +47004,15 @@
         }
       }
     },
+    "cql-worker": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/cql-worker/-/cql-worker-1.1.8.tgz",
+      "integrity": "sha512-Gk6uSb5pGzWVRuFjTMf5pL+tkfHXfAHoyndoOo8440FwB0Zno9WFY+aPmnKBsv6UD1p2DvSMpQqK4P6LZ5f67g==",
+      "requires": {
+        "cql-exec-fhir": "^2.1.4",
+        "cql-execution": "^3.0.1"
+      }
+    },
     "create-ecdh": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
@@ -47693,12 +47710,11 @@
       "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
     },
     "encender": {
-      "version": "git+ssh://git@github.com/ccsm-cds-tools/encender.git#8a3903cb282a45c46b5d12a96d24a23a052067f3",
-      "from": "encender@github:ccsm-cds-tools/encender#cql-execution",
+      "version": "git+ssh://git@github.com/ccsm-cds-tools/encender.git#38c091b061a4d8ba33b60ffadfa7fc5831bc55e2",
+      "from": "encender@github:ccsm-cds-tools/encender#add_cql_worker",
       "requires": {
         "@asymmetrik/fhir-json-schema-validator": "^0.9.8",
-        "cql-exec-fhir": "2.1.5",
-        "cql-execution": "^3.0.1",
+        "cql-worker": "1.1.8",
         "semver": "^6.3.0"
       },
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "css-minimizer-webpack-plugin": "^3.2.0",
         "dotenv": "^10.0.0",
         "dotenv-expand": "^5.1.0",
-        "encender": "github:ccsm-cds-tools/encender#add_cql_worker",
+        "encender": "github:ccsm-cds-tools/encender#cql-execution",
         "eslint": "^8.3.0",
         "eslint-config-react-app": "^7.0.1",
         "eslint-webpack-plugin": "^3.1.1",
@@ -12838,7 +12838,7 @@
     },
     "node_modules/encender": {
       "version": "0.7.1",
-      "resolved": "git+ssh://git@github.com/ccsm-cds-tools/encender.git#38c091b061a4d8ba33b60ffadfa7fc5831bc55e2",
+      "resolved": "git+ssh://git@github.com/ccsm-cds-tools/encender.git#8239c48fe4716efa8ee7085a3e4c33a1031ae239",
       "dependencies": {
         "@asymmetrik/fhir-json-schema-validator": "^0.9.8",
         "cql-worker": "1.1.8",
@@ -47710,8 +47710,8 @@
       "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
     },
     "encender": {
-      "version": "git+ssh://git@github.com/ccsm-cds-tools/encender.git#38c091b061a4d8ba33b60ffadfa7fc5831bc55e2",
-      "from": "encender@github:ccsm-cds-tools/encender#add_cql_worker",
+      "version": "git+ssh://git@github.com/ccsm-cds-tools/encender.git#8239c48fe4716efa8ee7085a3e4c33a1031ae239",
+      "from": "encender@github:ccsm-cds-tools/encender#cql-execution",
       "requires": {
         "@asymmetrik/fhir-json-schema-validator": "^0.9.8",
         "cql-worker": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "css-minimizer-webpack-plugin": "^3.2.0",
     "dotenv": "^10.0.0",
     "dotenv-expand": "^5.1.0",
-    "encender": "github:ccsm-cds-tools/encender#add_cql_worker",
+    "encender": "github:ccsm-cds-tools/encender#cql-execution",
     "eslint": "^8.3.0",
     "eslint-config-react-app": "^7.0.1",
     "eslint-webpack-plugin": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "css-minimizer-webpack-plugin": "^3.2.0",
     "dotenv": "^10.0.0",
     "dotenv-expand": "^5.1.0",
-    "encender": "github:ccsm-cds-tools/encender#cql-execution",
+    "encender": "github:ccsm-cds-tools/encender#add_cql_worker",
     "eslint": "^8.3.0",
     "eslint-config-react-app": "^7.0.1",
     "eslint-webpack-plugin": "^3.1.1",

--- a/src/hooks/useCds/index.js
+++ b/src/hooks/useCds/index.js
@@ -59,9 +59,9 @@ const applyCds = async function(patientData, setOutput, setIsLoadingCdsData, isT
 
   if (patientReference !== 'Patient/undefined') {
     // NOTE: CQL Worker is not used with cql-execution branch of encender
-    // const WorkerFactory = () => {
-    //   return new Worker(new URL('../../../node_modules/cql-worker/src/cql.worker.js', import.meta.url))
-    // };
+    const WorkerFactory = () => {
+      return new Worker(new URL('../../../node_modules/cql-worker/src/cql.worker.js', import.meta.url))
+    };
     
     // TODO: Move cqlParameters to a separate file within this directory and import them into this file
     const cqlParameters = {
@@ -71,7 +71,7 @@ const applyCds = async function(patientData, setOutput, setIsLoadingCdsData, isT
     const aux = {
       elmJsonDependencies,
       valueSetJson,
-      // WorkerFactory,
+      WorkerFactory,
       cqlParameters
     };
 


### PR DESCRIPTION
This PR allows the CDS Dashboard to leverage the latest update to Encender's cql-execution branch, which restores the use of CQL Worker for CQL Execution

* Restore WorkerFactory in applyCDS()
* Update package-lock.json to point to latest commit of Encender's cql-execution branch (https://github.com/ccsm-cds-tools/encender/pull/15) 