### PR TITLE
v0.3.3 / ccsm-cds-with-tests 0.4.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccsm-cds-dashboard",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ccsm-cds-dashboard",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "buffer": "^6.0.3",
         "camelcase": "^6.2.1",
         "case-sensitive-paths-webpack-plugin": "^2.4.0",
-        "ccsm-cds-with-tests": "^0.4.18",
+        "ccsm-cds-with-tests": "^0.4.19",
         "chai": "^4.3.10",
         "constants-browserify": "^1.0.0",
         "convert-csv-to-json": "^2.0.0",
@@ -10869,9 +10869,9 @@
       }
     },
     "node_modules/ccsm-cds-with-tests": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/ccsm-cds-with-tests/-/ccsm-cds-with-tests-0.4.18.tgz",
-      "integrity": "sha512-jhGCAWb/aKlG5rO/7qOj2OKVjGnCo6H5R3iQdQ9KiYyvYbgRKolIy6d5pHT7LAvw3KTDPXNaQwkxj5McYWKY0A==",
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/ccsm-cds-with-tests/-/ccsm-cds-with-tests-0.4.19.tgz",
+      "integrity": "sha512-AxWNdFqVonzOI0o6WB0+O7DZrR8hh29szThDmsWj+iePLb4pX3nTNQ7OX4M43GqknXHhDHJvHS2OAaQ5UlylPQ==",
       "dependencies": {
         "cql-testing": "^2.5.3"
       }
@@ -46307,9 +46307,9 @@
       "version": "2.4.0"
     },
     "ccsm-cds-with-tests": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/ccsm-cds-with-tests/-/ccsm-cds-with-tests-0.4.18.tgz",
-      "integrity": "sha512-jhGCAWb/aKlG5rO/7qOj2OKVjGnCo6H5R3iQdQ9KiYyvYbgRKolIy6d5pHT7LAvw3KTDPXNaQwkxj5McYWKY0A==",
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/ccsm-cds-with-tests/-/ccsm-cds-with-tests-0.4.19.tgz",
+      "integrity": "sha512-AxWNdFqVonzOI0o6WB0+O7DZrR8hh29szThDmsWj+iePLb4pX3nTNQ7OX4M43GqknXHhDHJvHS2OAaQ5UlylPQ==",
       "requires": {
         "cql-testing": "^2.5.3"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccsm-cds-dashboard",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "license": "Apache-2.0",
   "homepage": "/",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "buffer": "^6.0.3",
     "camelcase": "^6.2.1",
     "case-sensitive-paths-webpack-plugin": "^2.4.0",
-    "ccsm-cds-with-tests": "^0.4.18",
+    "ccsm-cds-with-tests": "^0.4.19",
     "chai": "^4.3.10",
     "constants-browserify": "^1.0.0",
     "convert-csv-to-json": "^2.0.0",


### PR DESCRIPTION
# Version 0.3.3 of ccsm-cds-dashboard:
- https://github.com/ccsm-cds-tools/ccsm-cds-dashboard/pull/63
- https://github.com/ccsm-cds-tools/ccsm-cds-dashboard/pull/64
- https://github.com/ccsm-cds-tools/ccsm-cds-dashboard/pull/66
- https://github.com/ccsm-cds-tools/ccsm-cds-dashboard/pull/67
- https://github.com/ccsm-cds-tools/ccsm-cds-dashboard/pull/69
- https://github.com/ccsm-cds-tools/ccsm-cds-dashboard/pull/70
- Bump ccsm-cds-with-tests dependency to v0.4.19 (https://github.com/ccsm-cds-tools/ccsm-cds-with-tests/pull/152)