### PR TITLE
Search for Order ID by 'Placer Indentifier' type, as opposed to by system code, which can change

### DIFF
--- a/src/hooks/useCds/translate.js
+++ b/src/hooks/useCds/translate.js
@@ -497,10 +497,10 @@ function mapStrideResult(patientData, patientDataMap, stridesData) {
 
   stridesPatientData.forEach(row => {
     const orderId = row['ORDER_ID'];
-    const diagnosticReport = patientDataMap.DiagnosticReport.find((dr) =>
-      dr.identifier.some(
+    const diagnosticReport = patientDataMap.DiagnosticReport?.find((dr) =>
+      dr.identifier?.some(
         (identifier) =>
-          identifier.type?.coding.some((coding) => coding.code === "PLAC") &&
+          identifier.type?.coding?.some((coding) => coding.code === "PLAC") &&
           identifier.value == orderId
       )
     );

--- a/src/hooks/useCds/translate.js
+++ b/src/hooks/useCds/translate.js
@@ -497,8 +497,13 @@ function mapStrideResult(patientData, patientDataMap, stridesData) {
 
   stridesPatientData.forEach(row => {
     const orderId = row['ORDER_ID'];
-    const diagnosticReport = patientDataMap.DiagnosticReport.find(
-      dr => dr.identifier.some(identifier => identifier.system === 'urn:oid:1.2.840.114350.1.13.284.3.7.2.798268' && identifier.value == orderId));
+    const diagnosticReport = patientDataMap.DiagnosticReport.find((dr) =>
+      dr.identifier.some(
+        (identifier) =>
+          identifier.type?.coding.some((coding) => coding.code === "PLAC") &&
+          identifier.value == orderId
+      )
+    );
 
     if (!diagnosticReport) return;
 

--- a/test/translate-test.js
+++ b/test/translate-test.js
@@ -115,6 +115,13 @@ describe('translate', () => {
       translateResponse(patientData, stridesData);
       expect(patientData.some(resource => resource.resourceType === 'DiagnosticReport')).to.be.false;
     });
+
+    it('should return when DiagnosticReport does not have identifier', () => {
+      const dr = patientData.find(pd => pd.resourceType === 'DiagnosticReport');
+      delete dr.identifier
+      translateResponse(patientData, stridesData);
+      expect(patientData.filter(resource => resource.resourceType === 'DiagnosticReport').length).to.equal(1);
+    });
   });
 
   describe('translate EpisodeOfCare', () => {

--- a/test/translate-test.js
+++ b/test/translate-test.js
@@ -64,6 +64,36 @@ describe('translate', () => {
       translateResponse(patientData, stridesData);
       expect(patientData.some(resource => resource.resourceType === 'DiagnosticReport' &&
                               resource.code.coding.some(coding => coding.code === '65753-6' && coding.system === 'http://loinc.org') &&
+                              resource.conclusionCode?.some(cc => cc.coding.some(coding => coding.system === 'urn:uuid:90915bcf-353c-49e1-b65e-0464798baa77')))
+            ).to.be.true;
+      expect(patientData.some(resource => resource.resourceType === 'Procedure' &&
+                              resource.code.coding.some(coding => coding.system == 'urn:uuid:273494e4-40f0-4a53-b1a3-2d30c32d76d1'))
+            ).to.be.true;
+    });
+
+    it('should recognize a diagnostic report with a different identifier system value', () => {
+      const dr = patientData.find(pd => pd.resourceType === 'DiagnosticReport');
+      const placerIdentifierNewSystemCode = 
+        {
+          "use": "official",
+          "type": {
+              "coding": [
+                  {
+                      "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                      "code": "PLAC",
+                      "display": "Placer Identifier"
+                  }
+              ],
+              "text": "Placer Identifier"
+          },
+          "system": "made-up-system",
+          "value": "258954111"
+      }
+      dr.identifier = [placerIdentifierNewSystemCode]
+      translateResponse(patientData, stridesData);
+
+      expect(patientData.some(resource => resource.resourceType === 'DiagnosticReport' &&
+                              resource.code.coding.some(coding => coding.code === '65753-6' && coding.system === 'http://loinc.org') &&
                               resource.conclusionCode?.some(cc => cc.coding.some(coding => coding.system == 'urn:uuid:90915bcf-353c-49e1-b65e-0464798baa77')))
             ).to.be.true;
       expect(patientData.some(resource => resource.resourceType === 'Procedure' &&


### PR DESCRIPTION
Pilot partner testing revealed that a FHIR resource's `identifier.system` field can change depending on what environment the data is coming from. This PR updates the STRIDES translation with translate.js to identify a DiagnosticReport's correct identifier by the "Placer Identifier" code, as opposed to the system-specific system code. This is a standard code - https://build.fhir.org/valueset-identifier-type.html - so we should not have to worry about it changing between environments.