### PR TITLE
Modernize tests-fhir patient data

### DIFF
--- a/src/test/fhir/TestPatientSelector.js
+++ b/src/test/fhir/TestPatientSelector.js
@@ -18,9 +18,9 @@ const managementData = [
   {
     key: 'joanne',
     name: 'Joanne42 Smith657',
-    age: '31',
+    age: '33',
     scenario: 'Management Table 4.',
-    updated: '7/21/2022'
+    updated: '11/18/2024'
   }
 ];
 const managementPad = screeningPad + screeningData.length;
@@ -53,8 +53,8 @@ export function TestPatientSelector() {
       </div>
 
       <h3>FHIR Test Patients</h3>
-      <b>Author:</b> David Winters (<a href="mailto:dwinters@mitre.org">dwinters@mitre.org</a>)<br/>
-      <b>Last Updated:</b> Jul 20, 2022<br/>
+      <b>Author:</b> Michael O'Hanlon (<a href="mailto:mohanlon@mitre.org">mohanlon@mitre.org</a>)<br/>
+      <b>Last Updated:</b> Nov 18, 2024<br/>
 
       <div className="sitemap">
 

--- a/src/test/fhir/TestPatientSelector.js
+++ b/src/test/fhir/TestPatientSelector.js
@@ -7,9 +7,9 @@ const screeningData = [
   {
     key: 'susan',
     name: 'Susan21 Holden65',
-    age: '42',
+    age: '44',
     scenario: 'Average risk screening; patient has history.',
-    updated: '7/20/2022'
+    updated: '11/21/2024'
   }
 ];
 const screeningPad = 1;
@@ -31,14 +31,14 @@ const incompleteData = [
     name: 'Paulina58 Vale56',
     age: '28',
     scenario: 'Average risk screening; patient has no history.',
-    updated: '7/20/2022'
+    updated: '11/21/2024'
   },
   {
     key: 'lily',
     name: 'Lily23 Flowers68',
-    age: '36',
+    age: '38',
     scenario: 'Post-biopsy; unstructured data in record.',
-    updated: '7/20/2022'
+    updated: '11/21/2024'
   }
 ];
 const incompletePad = managementPad + managementData.length;

--- a/src/test/fhir/testData.js
+++ b/src/test/fhir/testData.js
@@ -95,7 +95,7 @@ export const testData = {
               "text": "Negative for intraepithelial lesion or malignancy (finding)"
             }
           ],
-          "effectiveDateTime": "2016-09-22T00:00:00.000Z"
+          "effectiveDateTime": "2019-09-22T00:00:00.000Z"
         }
       },
       {
@@ -128,7 +128,7 @@ export const testData = {
               "text": "Negative for intraepithelial lesion or malignancy (finding)"
             }
           ],
-          "effectiveDateTime": "2011-07-15T00:00:00.000Z"
+          "effectiveDateTime": "2014-07-15T00:00:00.000Z"
         }
       },
       {
@@ -161,7 +161,7 @@ export const testData = {
               "text": "Negative for intraepithelial lesion or malignancy (finding)"
             }
           ],
-          "effectiveDateTime": "2007-01-22T00:00:00.000Z"
+          "effectiveDateTime": "2010-01-22T00:00:00.000Z"
         }
       },
       {
@@ -194,7 +194,7 @@ export const testData = {
               "text": "Negative for intraepithelial lesion or malignancy (finding)"
             }
           ],
-          "effectiveDateTime": "2003-11-07T00:00:00.000Z"
+          "effectiveDateTime": "2006-11-07T00:00:00.000Z"
         }
       },
       {
@@ -227,7 +227,7 @@ export const testData = {
               "text": "Human papillomavirus deoxyribonucleic acid test negative (finding)"
             }
           ],
-          "effectiveDateTime": "2016-09-22T00:00:00.000Z"
+          "effectiveDateTime": "2019-09-22T00:00:00.000Z"
         }
       }
     ]
@@ -250,7 +250,7 @@ export const testData = {
             }
           ],
           "gender": "female",
-          "birthDate": "1994-01-20",
+          "birthDate": "1996-01-20",
           "language": "en",
           "identifier" : [
             {
@@ -395,8 +395,30 @@ export const testData = {
             ],
             "text": "Cervix Pathology biopsy report"
           },
-          "conclusionCode": [],
-          "effectiveDateTime": "2021-08-25T00:00:00.000Z"
+          "conclusionCode": [
+          ],
+          "effectiveDateTime": "2024-08-25T00:00:00.000Z"
+        }
+      },
+      {
+        "resource": {
+          "resourceType": "Procedure",
+          "id": "cd0501d1-eb02-4da4-823b-23bdaee46528",
+          "subject": {
+            "reference": "Patient/25592edf-6b2b-43cb-a3e7-1d987a768eea"
+          },
+          "status": "completed",
+          "code": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "176786003",
+                "display": "Colposcopy of cervix (procedure)"
+              }
+            ],
+            "text": "Colposcopy of cervix (procedure)"
+          },
+          "performedDateTime": "2024-08-25T00:00:00.000Z"
         }
       },
       {
@@ -429,7 +451,7 @@ export const testData = {
               "text": "Deoxyribonucleic acid of Human papillomavirus 16 (substance)"
             }
           ],
-          "effectiveDateTime": "2021-08-17T00:00:00.000Z"
+          "effectiveDateTime": "2024-08-17T00:00:00.000Z"
         }
       },
       {
@@ -462,7 +484,7 @@ export const testData = {
               "text": "Low grade squamous intraepithelial lesion on cervical Papanicolaou smear (finding)"
             }
           ],
-          "effectiveDateTime": "2021-08-17T00:00:00.000Z"
+          "effectiveDateTime": "2024-08-17T00:00:00.000Z"
         }
       },
       {
@@ -495,7 +517,7 @@ export const testData = {
               "text": "Human papillomavirus deoxyribonucleic acid test negative (finding)"
             }
           ],
-          "effectiveDateTime": "2020-06-10T00:00:00.000Z"
+          "effectiveDateTime": "2023-06-10T00:00:00.000Z"
         }
       },
       {
@@ -528,7 +550,7 @@ export const testData = {
               "text": "Low grade squamous intraepithelial lesion on cervical Papanicolaou smear (finding)"
             }
           ],
-          "effectiveDateTime": "2020-06-10T00:00:00.000Z"
+          "effectiveDateTime": "2023-06-10T00:00:00.000Z"
         }
       },
       {
@@ -561,7 +583,7 @@ export const testData = {
               "text": "Human papillomavirus deoxyribonucleic acid test negative (finding)"
             }
           ],
-          "effectiveDateTime": "2016-10-15T00:00:00.000Z"
+          "effectiveDateTime": "2019-10-15T00:00:00.000Z"
         }
       }
     ]

--- a/src/test/fhir/testData.js
+++ b/src/test/fhir/testData.js
@@ -640,7 +640,7 @@ export const testData = {
               "text": "Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)"
             }
           ],
-          "effectiveDateTime": "2017-05-01T00:00:00.000Z"
+          "effectiveDateTime": "2020-05-01T00:00:00.000Z"
         }
       },
       {
@@ -673,7 +673,7 @@ export const testData = {
               "text": "Low grade squamous intraepithelial lesion on cervical Papanicolaou smear (finding)"
             }
           ],
-          "effectiveDateTime": "2017-05-01T00:00:00.000Z"
+          "effectiveDateTime": "2020-05-01T00:00:00.000Z"
         }
       },
       {
@@ -706,7 +706,7 @@ export const testData = {
               "text": "Cervical intraepithelial neoplasia grade 1 (disorder)"
             }
           ],
-          "effectiveDateTime": "2017-05-14T00:00:00.000Z"
+          "effectiveDateTime": "2020-05-14T00:00:00.000Z"
         }
       },
       {
@@ -739,7 +739,7 @@ export const testData = {
               "text": "Human papillomavirus deoxyribonucleic acid test negative (finding)"
             }
           ],
-          "effectiveDateTime": "2018-05-01T00:00:00.000Z"
+          "effectiveDateTime": "2021-05-01T00:00:00.000Z"
         }
       },
       {
@@ -772,7 +772,7 @@ export const testData = {
               "text": "Negative for intraepithelial lesion or malignancy (finding)"
             }
           ],
-          "effectiveDateTime": "2018-05-01T00:00:00.000Z"
+          "effectiveDateTime": "2021-05-01T00:00:00.000Z"
         }
       },
       {
@@ -805,7 +805,28 @@ export const testData = {
               "text": "Human papillomavirus deoxyribonucleic acid test positive, high risk on cervical specimen (finding)"
             }
           ],
-          "effectiveDateTime": "2021-05-01T00:00:00.000Z"
+          "effectiveDateTime": "2024-05-01T00:00:00.000Z"
+        }
+      },
+      {
+        "resource": {
+          "resourceType": "Procedure",
+          "id": "cd0501d1-eb02-4da4-823b-23bdaee46528",
+          "subject": {
+            "reference": "Patient/25592edf-6b2b-43cb-a3e7-1d987a768eea"
+          },
+          "status": "completed",
+          "code": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "176786003",
+                "display": "Colposcopy of cervix (procedure)"
+              }
+            ],
+            "text": "Colposcopy of cervix (procedure)"
+          },
+          "performedDateTime": "2020-05-14T00:00:00.000Z"
         }
       },
       {
@@ -838,7 +859,7 @@ export const testData = {
               "text": "Atypical squamous cells of undetermined significance on cervical Papanicolaou smear (finding)"
             }
           ],
-          "effectiveDateTime": "2021-05-01T00:00:00.000Z"
+          "effectiveDateTime": "2024-05-01T00:00:00.000Z"
         }
       }
     ]


### PR DESCRIPTION
While preparing for Safer World Symposium, I realized that our demo test cases have not been updated in years. This PR makes the following updates to our demo patients:

- Patient Selector:
   - Replace Dave's name and email with mine, since Dave no longer is on this project
   - Adjust ages so that they align with the current age of demo patients, who have "aged" since they were created
- Test Data:
   - Move test dates 3 years to the future, so that test that are supposed to be "recent" actually happened in the near past
   - Add Colposcopy procedures when there is a histology result, for completeness, and for the sake of showing something in the "Relevant Medical History" section for demos.
   - Update Paulina's birthday. She is supposed to represent a patient under 30, and she has no history anyways, so instead of making her lab results more recent, I kept her age consistent.