### PR TITLE
Add logger utility function and call after applyPlan

### DIFF
--- a/src/hooks/useCds/index.js
+++ b/src/hooks/useCds/index.js
@@ -5,6 +5,7 @@ import { cdsResources } from 'services/fhir';
 import { valueSetJson } from 'services/valuesets';
 import { translateResponse, translateToggleChange } from './translate';
 import { stridesData } from './strides';
+import { logMsg } from 'util/logger';
 
 /**
  *
@@ -144,6 +145,14 @@ const applyCds = async function(patientData, setOutput, setIsLoadingCdsData, isT
       decisionAids = { errors };
     }
 
+    // replace with actual logging data when ready from CQL 
+    // output otherResources as a temporary stand-in
+    logMsg({
+      time: new Date(),
+      patientReference: patientReference,
+      payload: otherResources
+    });
+    
     if (thereAreOutputs) {
       if (patientHistory.observations?.length > 0) {
         patientHistory.observations = patientHistory.observations.filter(obs => !obs.reference.includes('new-observation-for-'))

--- a/src/hooks/useCds/index.js
+++ b/src/hooks/useCds/index.js
@@ -147,8 +147,9 @@ const applyCds = async function(patientData, setOutput, setIsLoadingCdsData, isT
 
     // replace with actual logging data when ready from CQL 
     // output otherResources as a temporary stand-in
+    console.timeEnd('Apply CDS');
     logMsg({
-      time: new Date(),
+      timeRequestSent: new Date(),
       patientReference: patientReference,
       payload: otherResources
     });
@@ -175,7 +176,6 @@ const applyCds = async function(patientData, setOutput, setIsLoadingCdsData, isT
       patientReference
     }
 
-    console.timeEnd('Apply CDS');
     console.log('CDS output:', output);
     setIsLoadingCdsData(false);
     setOutput(output);

--- a/src/hooks/useCds/index.js
+++ b/src/hooks/useCds/index.js
@@ -7,6 +7,8 @@ import { translateResponse, translateToggleChange } from './translate';
 import { stridesData } from './strides';
 import { logMsg } from 'util/logger';
 
+const LOGGER_ENABLED = process.env?.REACT_APP_LOGGER_ENABLED || true;
+
 /**
  *
  * @param {Object[]} patientData
@@ -148,11 +150,14 @@ const applyCds = async function(patientData, setOutput, setIsLoadingCdsData, isT
     // replace with actual logging data when ready from CQL 
     // output otherResources as a temporary stand-in
     console.timeEnd('Apply CDS');
-    logMsg({
-      timeRequestSent: new Date(),
-      patientReference: patientReference,
-      payload: otherResources
-    });
+
+    if (LOGGER_ENABLED){
+      logMsg({
+        timeRequestSent: new Date(),
+        patientReference: patientReference,
+        payload: otherResources
+      });
+    }
     
     if (thereAreOutputs) {
       if (patientHistory.observations?.length > 0) {

--- a/src/hooks/useCds/index.js
+++ b/src/hooks/useCds/index.js
@@ -7,7 +7,7 @@ import { translateResponse, translateToggleChange } from './translate';
 import { stridesData } from './strides';
 import { logMsg } from 'util/logger';
 
-const LOGGER_ENABLED = process.env?.REACT_APP_LOGGER_ENABLED || true;
+const LOGGER_ENABLED = process.env?.REACT_APP_LOGGER_ENABLED || false;
 
 /**
  *

--- a/src/hooks/useCds/index.js
+++ b/src/hooks/useCds/index.js
@@ -155,7 +155,7 @@ const applyCds = async function(patientData, setOutput, setIsLoadingCdsData, isT
       logMsg({
         timeRequestSent: new Date(),
         patientReference: patientReference,
-        payload: otherResources
+        payload: [patientInfo, decisionAids]
       });
     }
     

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -2,9 +2,9 @@
 const LOGGER_HOST = process.env?.REACT_APP_LOGGER_HOST || "http://localhost"
 const LOGGER_PORT = process.env?.REACT_APP_LOGGER_PORT || "4040";
 const logger_url = `${LOGGER_HOST}:${LOGGER_PORT}/log`;
-console.log("Logging at", logger_url);
 
 export async function logMsg(msg) {
+  console.log("Logging at", logger_url);
   try {
     const response = await fetch(logger_url, {
       method: 'POST',

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -1,15 +1,8 @@
 // Use a custom logger application
-const LOGGER_HOST = process.env?.REACT_APP_LOGGER_HOST || "https://localhost"
+const LOGGER_HOST = process.env?.REACT_APP_LOGGER_HOST || "http://localhost"
 const LOGGER_PORT = process.env?.REACT_APP_LOGGER_PORT || "4040";
 const logger_url = `${LOGGER_HOST}:${LOGGER_PORT}/log`;
 console.log("Logging at", logger_url);
-
-const certPath = 'server.cert';
-const keyPath = 'server.key';
-
-const cert = fs.readFileSync(certPath);
-const key = fs.readFileSync(keyPath);
-console.log("Loaded certificate: ", certPath);
 
 export async function logMsg(msg) {
   try {
@@ -17,13 +10,10 @@ export async function logMsg(msg) {
       method: 'POST',
       headers: {
         'Accept': 'application/json',
-        'Content-Type': 'application/json',
-        'Content-Length': msg.length
+        'Content-Type': 'application/json'
       },
       mode:'cors',
-      body: JSON.stringify(msg),
-      cert: cert,
-      key: key
+      body: JSON.stringify(msg)
     }).then(response => {
               let cachedPostData = response.json();
     });

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -1,8 +1,15 @@
 // Use a custom logger application
-const LOGGER_HOST = process.env?.REACT_APP_LOGGER_HOST || "http://localhost"
+const LOGGER_HOST = process.env?.REACT_APP_LOGGER_HOST || "https://localhost"
 const LOGGER_PORT = process.env?.REACT_APP_LOGGER_PORT || "4040";
 const logger_url = `${LOGGER_HOST}:${LOGGER_PORT}/log`;
-console.log("Logging at", logger_url)
+console.log("Logging at", logger_url);
+
+const certPath = 'server.cert';
+const keyPath = 'server.key';
+
+const cert = fs.readFileSync(certPath);
+const key = fs.readFileSync(keyPath);
+console.log("Loaded certificate: ", certPath);
 
 export async function logMsg(msg) {
   try {
@@ -11,9 +18,12 @@ export async function logMsg(msg) {
       headers: {
         'Accept': 'application/json',
         'Content-Type': 'application/json',
+        'Content-Length': msg.length
       },
       mode:'cors',
-      body: JSON.stringify(msg)
+      body: JSON.stringify(msg),
+      cert: cert,
+      key: key
     }).then(response => {
               let cachedPostData = response.json();
     });

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -2,9 +2,10 @@
 const LOGGER_HOST = process.env?.REACT_APP_LOGGER_HOST || "http://localhost"
 const LOGGER_PORT = process.env?.REACT_APP_LOGGER_PORT || "4040";
 const logger_url = `${LOGGER_HOST}:${LOGGER_PORT}/log`;
+console.log("Logging at", logger_url);
 
 export async function logMsg(msg) {
-  console.log("Logging at", logger_url);
+  console.time('Logged FHIR Data');
   try {
     const response = await fetch(logger_url, {
       method: 'POST',
@@ -15,7 +16,8 @@ export async function logMsg(msg) {
       mode:'cors',
       body: JSON.stringify(msg)
     }).then(response => {
-              let cachedPostData = response.json();
+      let cachedPostData = response.json();
+      console.timeEnd('Logged FHIR Data');
     });
   } catch (e) {
     console.log("No response from log service")

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -1,0 +1,24 @@
+// Use a custom logger application
+const LOGGER_HOST = process.env?.REACT_APP_LOGGER_HOST || "http://localhost"
+const LOGGER_PORT = process.env?.REACT_APP_LOGGER_PORT || "4040";
+const logger_url = `${LOGGER_HOST}:${LOGGER_PORT}/log`;
+console.log("Logging at", logger_url)
+
+export async function logMsg(msg) {
+  try {
+    const response = await fetch(logger_url, {
+      method: 'POST',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+      },
+      mode:'cors',
+      body: JSON.stringify(msg)
+    }).then(response => {
+              let cachedPostData = response.json();
+    });
+  } catch (e) {
+    console.log("No response from log service")
+  }
+
+}


### PR DESCRIPTION
Address [CCSMCDS-304](https://jira.mitre.org/browse/CCSMCDS-304) to add logging capability to Dashboard.
This adds a logMsg function, and will do a POST to a logging service.
Configuration of logger host and port through `.env` files by adding below:

`REACT_APP_LOGGER_ENABLED = true`

At the moment, it is simply logging otherResources from applyPlan. When the CQL is updated to provide logging data through custom Plan Definition, we can update. 
To test, you will need to download and run the [cds-dashboard-logger](https://github.com/ccsm-cds-tools/cds-dashboard-logger)

If logger is not running, you should see console message "No response from log service"
At app startup, it will console.log the url ("Logging at http://localhost:4040/log") indicating host and port read from .env files (if available). Whenever successfully logged, it will console.log logging elapsed time.

You can use either `http` or `https`, by setting up `REACT_APP_LOGGER_HOST` in `.env`, for example:

`REACT_APP_LOGGER_HOST = http://localhost`
`REACT_APP_LOGGER_HOST = https://localhost`