### PR TITLE
CCSMCDS-321 handle bad dates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11802,7 +11802,8 @@
     },
     "node_modules/cql-exec-fhir": {
       "version": "2.1.5",
-      "resolved": "git+ssh://git@github.com/ccsm-cds-tools/cql-exec-fhir.git#d6188beea6e17163943a17b2a592b57a780196de",
+      "resolved": "git+ssh://git@github.com/ccsm-cds-tools/cql-exec-fhir.git#f70a9fe2c1200a783b56b49ce30fd2b7e312264c",
+      "license": "Apache-2.0",
       "dependencies": {
         "xml2js": "^0.5.0"
       },
@@ -47430,7 +47431,7 @@
       }
     },
     "cql-exec-fhir": {
-      "version": "git+ssh://git@github.com/ccsm-cds-tools/cql-exec-fhir.git#d6188beea6e17163943a17b2a592b57a780196de",
+      "version": "git+ssh://git@github.com/ccsm-cds-tools/cql-exec-fhir.git#f70a9fe2c1200a783b56b49ce30fd2b7e312264c",
       "from": "cql-exec-fhir@github:ccsm-cds-tools/cql-exec-fhir#memoize-to-fhir-object",
       "requires": {
         "xml2js": ">=0.5.0"

--- a/src/util/formatDate.js
+++ b/src/util/formatDate.js
@@ -1,15 +1,19 @@
 /* 
- * Accept string containing a date in YYYY-MM-DD format
+ * Accept string containing a date in YYYY-MM-DD format or
+ * an object with {year:YYYY, month:MM, day:DD}
  * Return date as MM/DD/YYYY string 
  * Assumes UTC (Z) for all dates
+ * Reject [], [{object}], "", {}, null, "non-date-string" as "Date Unknown"
  */
+import dayjs from 'dayjs';
 
 export function formatDate(date) {
-  const dateFormat = new Intl.DateTimeFormat("en-US",{year:"numeric",month:"2-digit",day:"2-digit",timeZone:"UTC"});
-  if (typeof date === "object")
-  {
-    date = [String(date?.month ?? ''), String(date?.day ?? ''), String(date?.year ?? '')].join('/');
-  }
-  return date ? dateFormat.format(new Date(date)) : null;
+  if (date !== undefined && date !== null && (typeof date === "object" || typeof date === "string")) {
+    if (typeof date === "object" && Object.keys(date).length > 0) {
+      date = [String(date?.month ?? ''), String(date?.day ?? ''), String(date?.year ?? '')].join('/');
+    }
+    return dayjs(date).isValid() ? dayjs(date).format("MM/DD/YYYY") : "Date Unknown";
+  } else {return "Date Unknown"}
 }
+
 


### PR DESCRIPTION
Discovered that null dates could cause fatal React error when trying to format for the dashboard. 
This switches to using dayjs library and adds checks to avoid trying to process non-dates. 
Unrecognized or missing date values will be shown as "Date Unknown" - this is consistent with the CDS Hooks display and the Surgical History display in Epic when a date is not available.

Validate with test patients with missing dates (e.g. a Procedure without procedureDateTime), null date, empty array, empty object and non-date string. 

 