### PR TITLE
Add optional chaining op to identifier to prevent crash 

### DIFF
--- a/src/features/PatientInfo/index.js
+++ b/src/features/PatientInfo/index.js
@@ -33,7 +33,7 @@ function getMrn(ids) {
     const mrnTextValues = ["MRN", "MR", "Medical Record Number"]
     const mrn = ids.find(id =>
       mrnTextValues.includes(id.type?.text?.value)||
-      (id.type?.coding && mrnTextValues.includes(id.type?.coding[0].code.value))
+      (id.type?.coding && mrnTextValues.includes(id.type?.coding[0]?.code?.value))
     );
     return mrn ? mrn.value.value : 'Unknown';
   } else {

--- a/src/features/PatientInfo/index.js
+++ b/src/features/PatientInfo/index.js
@@ -32,7 +32,7 @@ function getMrn(ids) {
   if (ids.length > 0) {
     const mrnTextValues = ["MRN", "MR", "Medical Record Number"]
     const mrn = ids.find(id =>
-      mrnTextValues.includes(id.type?.text.value)||
+      mrnTextValues.includes(id.type?.text?.value)||
       (id.type?.coding && mrnTextValues.includes(id.type?.coding[0].code.value))
     );
     return mrn ? mrn.value.value : 'Unknown';


### PR DESCRIPTION
If the patient "identifier" array has an entry without the "text" attribute, the Dashboard would crash with `undefined is not an object (evaluating '_id$type.text.value')`
This adds the optional chaining operator to check if 'text' exists before trying to get its value. 
I encountered this bug on trying to parse a breast cancer CDS patient, which don't have "text" attributes in their "identifier" 