### PR TITLE
Add extra highlight class for incomplete results

### DIFF
--- a/src/components/SortableTable/index.js
+++ b/src/components/SortableTable/index.js
@@ -15,7 +15,7 @@ function SortableTable(props) {
   const ascendingOrDescending = (name) => {
     return sortConfig?.key === name ? sortConfig.direction : 'none';
   };
-  const highlightClass = ['unknown','normal','high'];
+  const highlightClass = ['unknown','normal','high','incomplete'];
   
   if (items.length === 0) return <div></div>
   else return(

--- a/src/components/SortableTable/style.scss
+++ b/src/components/SortableTable/style.scss
@@ -69,7 +69,7 @@ table.sortable {
   }
 
 
-  tr.incomplete {
+  tr.incomplete td {
     background-color: #fbecee;
     color: #9a2029;
     text-transform:uppercase;


### PR DESCRIPTION
Due to CCSMCDS-336, there is a change to how null results (conclusions) are being interpreted, and the Dashboard needed an extra CSS class to show these as highlighted missing result values. 