### PR TITLE
Restore call to fetch immunization data at pilot request

### DIFF
--- a/src/smart/SmartPatient.js
+++ b/src/smart/SmartPatient.js
@@ -50,7 +50,7 @@ export function SmartPatient() {
 
       // promises.push(client.request(`/Condition?patient=${pid}&category=problem-list-item,medical-history`).then(fhirParser));
       promises.push(client.request(`/DiagnosticReport?patient=${pid}&category=http://terminology.hl7.org/CodeSystem/v2-0074|Lab`).then(fhirParser));
-      // promises.push(client.request(`/Immunization?patient=${pid}&status=completed&vaccine-code=118,137,165,62`).then(fhirParser));
+      promises.push(client.request(`/Immunization?patient=${pid}&status=completed&vaccine-code=118,137,165,62`).then(fhirParser));
       // promises.push(client.request(`/MedicationRequest?patient=${pid}&status=completed`).then(fhirParser));
       promises.push(client.request(`/Procedure?patient=${pid}&status=completed&category=http://snomed.info/sct|103693007,http://snomed.info/sct|387713003`).then(fhirParser)); // Search Procedures with category of Diagnostic procedure or Surgical procedure
 


### PR DESCRIPTION
Fix for CCSMCDS-331 Re-add Immunization history to dashboard.
Pilot site reports seeing the HPV immunization history would be extremely useful and requested we restore this now that performance issues have settled down.
