### PR TITLE
Add additional CPT codes to Dashboard translation

### DIFF
--- a/src/hooks/useCds/translate.js
+++ b/src/hooks/useCds/translate.js
@@ -664,8 +664,12 @@ function mapEpisodeOfCare(episodeOfCare) {
 
 function mapCptCode(procedure, cptMapping) {
   if (!procedure.code?.coding?.length) return;
-
-  const existingCodes = new Set(procedure.code.coding.map(coding => coding.code));
+  
+  const existingCodes = new Set(
+    procedure.code.coding
+      .filter(coding => coding.system === CPT_URL)
+      .map(coding => coding.code)
+  );
 
   for (const { oldCode, newCodings } of cptMapping) {
     if (existingCodes.has(oldCode)) {

--- a/src/hooks/useCds/translate.js
+++ b/src/hooks/useCds/translate.js
@@ -216,20 +216,20 @@ const stridesCodeMapping = {
 
 const loincMapping = [
   {
-    oldCode: '49896-4',
-    newCode: '82675-0'
+    oldCode: '49896-4', // Human papilloma virus 16+18+31+33+35+39+45+51+52+56+58+59+68 DNA [Presence] in Specimen by NAA with probe detection	
+    newCode: '82675-0' // Human papilloma virus 16+18+31+33+35+39+45+51+52+56+58+59+66+68 DNA [Presence] in Cervix by NAA with probe detection	
   },
   {
-    oldCode: '61372-9',
-    newCode: '77399-4'
+    oldCode: '61372-9', // Human papilloma virus 16 DNA [Presence] in Specimen by NAA with probe detection	
+    newCode: '77399-4'// Human papilloma virus 16 DNA [Presence] in Cervix by NAA with probe detection	
   },
   {
-    oldCode: '61373-7',
-    newCode: '77400-0'
+    oldCode: '61373-7', // Human papilloma virus 18 DNA [Presence] in Specimen by NAA with probe detection	
+    newCode: '77400-0' // Human papilloma virus 18 DNA [Presence] in Cervix by NAA with probe detection	
   },
   {
-    oldCode: '50595-8',
-    newCode: '47527-7'
+    oldCode: '50595-8', // Pathologist interpretation of Specimen tests	
+    newCode: '47527-7' // Cytology report of Cervical or vaginal smear or scraping Cyto stain.thin prep	
   }
 ];
 

--- a/src/hooks/useCds/translate.js
+++ b/src/hooks/useCds/translate.js
@@ -233,8 +233,74 @@ const loincMapping = [
   }
 ];
 
+const procedureCodings = {
+  colposcopy:
+    {
+      system: 'http://snomed.info/sct',
+      code: '392003006',
+      display: 'Colposcopy (procedure)'
+    },
+  ecc:
+    {
+      system: 'http://snomed.info/sct',
+      code: '52889002',
+      display: 'Endocervical curettage (procedure)'
+    },
+  leep:
+    {
+      system: 'http://snomed.info/sct',
+      code: '23140002',
+      display: 'Loop electrosurgical excision procedure of cervix (procedure)'
+    }
+}
+
+const cptMapping = [
+  {
+    oldCode: '57420', // colpo of vagina
+    newCodings: [procedureCodings.colposcopy]
+  },
+  {
+    oldCode: '57421', // colpo of vagina w/bx
+    newCodings: [procedureCodings.colposcopy]
+  },
+  {
+    oldCode: '57452', // colpo of cervix
+    newCodings: [procedureCodings.colposcopy]
+  },
+  {
+    oldCode: '57454', // colpo of cervix w/bx and ECC
+    newCodings: [procedureCodings.colposcopy, procedureCodings.ecc]
+  },
+  {
+    oldCode: '57455', // colpo of cervix w/bx
+    newCodings: [procedureCodings.colposcopy]
+  },
+  {
+    oldCode: '57456', // colpo of cervix w/ECC
+    newCodings: [procedureCodings.colposcopy, procedureCodings.ecc]
+  },
+  {
+    oldCode: '57460', // colpo of cervix w/loop or LEEP bx
+    newCodings: [procedureCodings.colposcopy, procedureCodings.leep]
+  },
+  {
+    oldCode: '57461', // colpo of cervix w/loop or LEEP conization
+    newCodings: [procedureCodings.colposcopy, procedureCodings.leep]
+  },
+  {
+    oldCode: '58110', // Endo bx when done w/colpo (use colpo code and endo bx code)
+    newCodings: [procedureCodings.colposcopy]
+  },
+  // Conization of cervix, knife/laser is already a concept in ccsm-cds-with-tests
+  // {
+  //   oldCode: '57520', // CKC
+  //   newCodings: [procedureCodings.colposcopy]
+  // },
+];
+
 const SCT_URL = 'http://snomed.info/sct';
 const LOINC_URL = 'http://loinc.org';
+const CPT_URL = 'http://www.ama-assn.org/go/cpt';
 const LOCAL_URL = 'http://OUR-PLACEHOLDER-URL.com';
 const STRIDES_DIAG_URI = 'urn:uuid:90915bcf-353c-49e1-b65e-0464798baa77';
 const STRIDES_PROC_URI = 'urn:uuid:273494e4-40f0-4a53-b1a3-2d30c32d76d1';
@@ -363,6 +429,7 @@ export function translateResponse(patientData, stridesData) {
 
   patientDataMap.Observation?.forEach(pd => mapResult(pd, loincMapping, testCodeResultMapping));
   patientDataMap.DiagnosticReport?.forEach(pd => mapResult(pd, loincMapping, testCodeResultMapping));
+  patientDataMap.Procedure?.forEach(procedure => mapCptCode(procedure, cptMapping));
   patientDataMap.EpisodeOfCare?.forEach(episodeOfCare => mapEpisodeOfCare(episodeOfCare));
 
   if (stridesData && Object.keys(stridesData).length > 0) {
@@ -591,6 +658,19 @@ function mapEpisodeOfCare(episodeOfCare) {
 
     if (!pregnancyType.text) {
       pregnancyType.text = epicCoding.display;
+    }
+  }
+}
+
+function mapCptCode(procedure, cptMapping) {
+  if (!procedure.code?.coding?.length) return;
+
+  const existingCodes = new Set(procedure.code.coding.map(coding => coding.code));
+
+  for (const { oldCode, newCodings } of cptMapping) {
+    if (existingCodes.has(oldCode)) {
+      procedure.code.coding.push(...newCodings);
+      break;
     }
   }
 }

--- a/test/fixtures/translate/patientData.json
+++ b/test/fixtures/translate/patientData.json
@@ -355,6 +355,83 @@
       ]
     },
     {
+      "resourceType": "Procedure",
+      "id": "eiPOcxzeMPraFfhtYrDORrhnHRZWo2dSMSg8ODMV8WBq0Kq4lrgfa9TJMkSnJZJA83",
+      "identifier": [
+          {
+              "use": "usual",
+              "type": {
+                  "text": "ORD"
+              },
+              "system": "urn:oid:1.2.840.114350.1.13.284.3.7.2.798268",
+              "value": "26802378"
+          },
+          {
+              "use": "usual",
+              "type": {
+                  "text": "EAP"
+              },
+              "system": "urn:oid:1.2.840.114350.1.13.284.3.7.2.696580",
+              "value": "80435"
+          },
+          {
+              "use": "usual",
+              "type": {
+                  "text": "OPE"
+              },
+              "system": "urn:oid:1.2.840.114350.1.13.284.3.7.2.798069",
+              "value": "126"
+          }
+      ],
+      "status": "completed",
+      "category": {
+          "coding": [
+              {
+                  "system": "http://snomed.info/sct",
+                  "code": "103693007",
+                  "display": "Diagnostic procedure"
+              }
+          ],
+          "text": "Ordered Procedures"
+      },
+      "code": {
+          "coding": [
+              {
+                  "system": "http://www.ama-assn.org/go/cpt",
+                  "code": "57461",
+                  "display": "PR COLPOSCPY,LEEP+CONIZATION"
+              }
+          ],
+          "text": "LEEP"
+      },
+      "subject": {
+        "reference": "Patient/e4PvGpeKAVwquQqfBlWYLdzjlsu6fhhCrteqmVJpQ0nM3",
+        "display": "Mitre, Fiftyfour"
+      },
+      "encounter": {
+          "reference": "Encounter/ecJpaWpEFf.RWJVT-K4VYMA3",
+          "identifier": {
+              "use": "usual",
+              "system": "urn:oid:1.2.840.114350.1.13.284.3.7.3.698084.8",
+              "value": "6000066301"
+          },
+          "display": "Procedure visit"
+      },
+      "performedDateTime": "2023-08-09T13:00:00Z",
+      "reasonCode": [
+          {
+              "coding": [
+                  {
+                      "system": "http://hl7.org/fhir/sid/icd-9-cm/diagnosis",
+                      "code": "V76.2",
+                      "display": "Cervical cancer screening"
+                  }
+              ],
+              "text": "Cervical cancer screening"
+          }
+      ]
+    },
+    {
       "resourceType" : "EpisodeOfCare",
       "id" : "episdoeofcare-1",
       "status" : "active",

--- a/test/translate-test.js
+++ b/test/translate-test.js
@@ -57,7 +57,6 @@ describe('translate', () => {
 
     it('should translate CPT code from a Procedure', () => {
       translateResponse(patientData);
-      console.dir(patientData.find(pd => pd.resourceType === 'Procedure'), { depth: null });
 
       expect(patientData.some(resource =>
         resource.resourceType === 'Procedure' &&

--- a/test/translate-test.js
+++ b/test/translate-test.js
@@ -54,6 +54,18 @@ describe('translate', () => {
         resource.code?.coding?.some(coding => coding.system === 'http://loinc.org' && coding.code === '82675-0')
       )).to.be.true
     });
+
+    it('should translate CPT code from a Procedure', () => {
+      translateResponse(patientData);
+      console.dir(patientData.find(pd => pd.resourceType === 'Procedure'), { depth: null });
+
+      expect(patientData.some(resource =>
+        resource.resourceType === 'Procedure' &&
+        resource.code?.coding?.some(coding => coding.system === 'http://snomed.info/sct' && coding.code === '23140002') && // Loop electrosurgical excision procedure of cervix (procedure)
+        resource.code?.coding?.some(coding => coding.system === 'http://snomed.info/sct' && coding.code === '392003006') // CColposcopy (procedure)
+      )).to.be.true;
+    });
+
   });
 
   describe('maps strides data', () => {


### PR DESCRIPTION
Addresses [CCSMCDS-354](https://jira.mitre.org/browse/CCSMCDS-354)

Every time a Procedure is recognized with a CPT code from our pilot partner's list, we will add our SNOMED-CT equivalent so that the Procedure can be recognized by our CDS. Some CPT codes require adding multiple SNOMED-CT codes, since they represent multiple concepts in our CDS.

Added a test to show this functionality, which can be run via `npm run test-mocha test/translate-test.js`