### PR TITLE
Log additional Dashboard data

### DIFF
--- a/src/hooks/useCds/index.js
+++ b/src/hooks/useCds/index.js
@@ -40,7 +40,7 @@ export const useCds = (patientData, toggleStatus) => {
     console.timeEnd('Translate FHIR Data');
     console.log('patientData after translation: ', patientData);
 
-    applyCds(patientData, setOutput, setIsLoadingCdsData, toggleStatus.isToggleChanged, isPregnant, setIsPreganant);
+    applyCds(patientData, setOutput, setIsLoadingCdsData, toggleStatus, isPregnant, setIsPreganant);
   }, [patientData, toggleStatus, isPregnant]);
 
   return {output, isLoadingCdsData};
@@ -51,7 +51,7 @@ export const useCds = (patientData, toggleStatus) => {
  * @param {Object[]} patientData
  * @param {function} setOutput
  */
-const applyCds = async function(patientData, setOutput, setIsLoadingCdsData, isToggleChanged, isPregnant, setIsPreganant) {
+const applyCds = async function(patientData, setOutput, setIsLoadingCdsData, toggleStatus, isPregnant, setIsPreganant) {
   console.log('Starting applyCds()');
   console.time('Apply CDS');
   const cdsApplyStart = Date.now();
@@ -61,6 +61,12 @@ const applyCds = async function(patientData, setOutput, setIsLoadingCdsData, isT
   const patientReference = 'Patient/' + patientData.filter(pd => pd.resourceType === 'Patient').map(pd => pd.id)[0];
 
   if (patientReference !== 'Patient/undefined') {
+    let isToggleChanged = toggleStatus.isToggleChanged;
+    let patientInfo={};
+    let patientHistory={};
+    let decisionAids={};
+    let thereAreOutputs = false;
+    
     // NOTE: CQL Worker is not used with cql-execution branch of encender
     const WorkerFactory = () => {
       return new Worker(new URL('../../../node_modules/cql-worker/src/cql.worker.js', import.meta.url))
@@ -82,6 +88,8 @@ const applyCds = async function(patientData, setOutput, setIsLoadingCdsData, isT
             cdsApplyEnd: Date.now(),
             timeRequestSent: new Date(),
             patientReference: patientReference,
+            patientInfo: patientInfo,
+            toggleStatus: toggleStatus,
             payload: JSON.parse(analyticsOutput)
           });
           worker.terminate();
@@ -122,11 +130,6 @@ const applyCds = async function(patientData, setOutput, setIsLoadingCdsData, isT
     console.log('CarePlan: ', CarePlan);
     console.log('RequestGroup: ', RequestGroup);
     console.log('otherResources: ', otherResources);
-
-    let patientInfo={};
-    let patientHistory={};
-    let decisionAids={};
-    let thereAreOutputs = false;
 
     if (DisplayCervicalCancerMedicalHistory?.payload?.length > 0) {
       let historyString = DisplayCervicalCancerMedicalHistory.payload[0].contentString;


### PR DESCRIPTION
Add two additional objects to the call to the logger: patientInfo and toggleStatus
The CDS AnalyticsLibrary doesn't currently export patient information, as it isn't necessary for CDS recommendations (other than age/sex) and the toggleStatus is Dashboard-specific. 
Needed to refactor code a little to move variable declarations forward, and pass toggleStatus to applyPlan.
Output in log should now include extra attributes:
```
  patientInfo: {
    name: 'Susan21 Holden65',
    id: [ [Object] ],
    isPregnant: false,
    dateOfBirth: { value: [Object] },
    sexAtBirth: 'Female',
    age: 44,
    gender: 'female',
    primaryLanguage: 'French',
    race: 'Black or African American; Not Hispanic or Latino'
  },
  toggleStatus: {
    isImmunosuppressed: false,
    isPregnant: false,
    isPregnantConcerned: false,
    isSymptomatic: false,
    isToggleChanged: false
  },
``` 