### PR TITLE
Add CDS apply time and logger status to hidden status bar

### DIFF
--- a/src/components/StatusBar/index.js
+++ b/src/components/StatusBar/index.js
@@ -1,0 +1,20 @@
+import { LOGGER_URL, LOGGER_ENABLED } from 'util/logger';
+import './style.scss';
+
+function StatusBar(props) {
+  const { 
+    logStatus, 
+    applyTime
+  } = props;
+
+  return (
+        <div className="cds-status">
+          <span>CDS Apply Time: {applyTime}ms</span>
+          {LOGGER_ENABLED && (
+            <span> | <span title={LOGGER_URL + " - " + logStatus}>Log Status: <span id="log_status" className={logStatus}>&diams;</span></span></span>
+          )}
+        </div>
+  )
+}
+
+export default StatusBar;

--- a/src/components/StatusBar/style.scss
+++ b/src/components/StatusBar/style.scss
@@ -1,0 +1,5 @@
+.cds-status {font-size:9pt;opacity:0;color:#444;transition:1s; display:inline-block;}
+.cds-status:hover, .status:focus {transition:1.5ss;opacity:1;}
+#log_status.pending {color:orange}
+#log_status.success {color:green}
+#log_status.fail {color:red}

--- a/src/hooks/useCds/index.js
+++ b/src/hooks/useCds/index.js
@@ -18,6 +18,7 @@ const LOGGER_ENABLED = process.env?.REACT_APP_LOGGER_ENABLED || false;
 export const useCds = (patientData, toggleStatus) => {
   const [output, setOutput] = useState({});
   const [isLoadingCdsData, setIsLoadingCdsData] = useState(false);
+  const [logStatus, setLogStatus] = useState();
   const [isPregnant, setIsPreganant] = useState(false);
 
   useEffect(() => {
@@ -26,6 +27,7 @@ export const useCds = (patientData, toggleStatus) => {
     }
 
     setIsLoadingCdsData(true);
+    setLogStatus("pending");
 
     console.log('toggleStatus: ', toggleStatus);
     console.log('patientData before translation: ', patientData);
@@ -40,10 +42,10 @@ export const useCds = (patientData, toggleStatus) => {
     console.timeEnd('Translate FHIR Data');
     console.log('patientData after translation: ', patientData);
 
-    applyCds(patientData, setOutput, setIsLoadingCdsData, toggleStatus, isPregnant, setIsPreganant);
+    applyCds(patientData, setOutput, setIsLoadingCdsData, setLogStatus, toggleStatus, isPregnant, setIsPreganant);
   }, [patientData, toggleStatus, isPregnant]);
 
-  return {output, isLoadingCdsData};
+  return {output, isLoadingCdsData, logStatus};
 }
 
 /**
@@ -51,7 +53,7 @@ export const useCds = (patientData, toggleStatus) => {
  * @param {Object[]} patientData
  * @param {function} setOutput
  */
-const applyCds = async function(patientData, setOutput, setIsLoadingCdsData, toggleStatus, isPregnant, setIsPreganant) {
+const applyCds = async function(patientData, setOutput, setIsLoadingCdsData, setLogStatus, toggleStatus, isPregnant, setIsPreganant) {
   console.log('Starting applyCds()');
   console.time('Apply CDS');
   const cdsApplyStart = Date.now();
@@ -83,7 +85,8 @@ const applyCds = async function(patientData, setOutput, setIsLoadingCdsData, tog
       const worker = new Worker(new URL('./analyticsWorker.js', import.meta.url));
       worker.postMessage( { patientData, patientReference });
       worker.onmessage = ({data:{analyticsOutput}}) => {
-          logMsg({
+          
+          (async () => {setLogStatus(await logMsg({
             cdsApplyStart: cdsApplyStart,
             cdsApplyEnd: Date.now(),
             timeRequestSent: new Date(),
@@ -91,7 +94,8 @@ const applyCds = async function(patientData, setOutput, setIsLoadingCdsData, tog
             patientInfo: patientInfo,
             toggleStatus: toggleStatus,
             payload: JSON.parse(analyticsOutput)
-          });
+          })
+          )})()
           worker.terminate();
       };
     }
@@ -161,7 +165,7 @@ const applyCds = async function(patientData, setOutput, setIsLoadingCdsData, tog
     }
 
     console.timeEnd('Apply CDS');
-
+    const cdsApplyEnd = Date.now();
     if (thereAreOutputs) {
       if (patientHistory.observations?.length > 0) {
         patientHistory.observations = patientHistory.observations.filter(obs => !obs.reference.includes('new-observation-for-'))
@@ -181,7 +185,8 @@ const applyCds = async function(patientData, setOutput, setIsLoadingCdsData, tog
       patientHistory,
       decisionAids,
       resolver: (r) => r === '' ? {} : resolver(r),
-      patientReference
+      patientReference,
+      applyTime: cdsApplyEnd - cdsApplyStart
     }
 
     console.log('CDS output:', output);

--- a/src/hooks/useCds/index.js
+++ b/src/hooks/useCds/index.js
@@ -81,11 +81,13 @@ const applyCds = async function(patientData, setOutput, setIsLoadingCdsData, set
       cqlParameters
     };
     
+    let applyPromise = applyPlan(planDefinition, patientReference, resolver, aux);
+
     if (LOGGER_ENABLED) {
       const worker = new Worker(new URL('./analyticsWorker.js', import.meta.url));
       worker.postMessage( { patientData, patientReference });
       worker.onmessage = ({data:{analyticsOutput}}) => {
-          
+        applyPromise.then(() => {
           (async () => {setLogStatus(await logMsg({
             cdsApplyStart: cdsApplyStart,
             cdsApplyEnd: Date.now(),
@@ -97,10 +99,11 @@ const applyCds = async function(patientData, setOutput, setIsLoadingCdsData, set
           })
           )})()
           worker.terminate();
+        });
       };
     }
-    
-    const [CarePlan, RequestGroup, ...otherResources] = await applyPlan(planDefinition, patientReference, resolver, aux);
+
+    const [CarePlan, RequestGroup, ...otherResources] = await applyPromise;
 
     let CommunicationRequests = otherResources.filter(otr => otr.resourceType === 'CommunicationRequest');
     let DisplayCervicalCancerMedicalHistory = CommunicationRequests.filter(cr => {

--- a/src/smart/SmartPatient.js
+++ b/src/smart/SmartPatient.js
@@ -3,6 +3,7 @@ import FHIR from 'fhirclient';
 import Dashboard from 'features/Dashboard';
 import { useCds } from 'hooks/useCds';
 import { config } from './smart.config.js';
+import StatusBar from 'components/StatusBar';
 
 export function SmartPatient() {
 
@@ -18,8 +19,10 @@ export function SmartPatient() {
     isToggleChanged: false
   });
 
-  const { output: dashboardInput, isLoadingCdsData } = useCds(patientData, toggleStatus);
+  const { output: dashboardInput, isLoadingCdsData, logStatus } = useCds(patientData, toggleStatus);
   const isLoading = isLoadingFHIRData || isLoadingCdsData;
+  const applyTime = dashboardInput.applyTime || 0;
+
   useEffect(() => {
     FHIR.oauth2.ready().then((client)=>{
       console.log(client);
@@ -214,6 +217,10 @@ if (process.env?.REACT_APP_DEBUG_FHIR==='true') {
         onToggleStatusChange={setToggleStatus}
       />
       </div>
+        <StatusBar
+          logStatus={logStatus}
+          applyTime={applyTime}
+        />
     </div>
   )
 }

--- a/src/test/fhir/TestPatient.js
+++ b/src/test/fhir/TestPatient.js
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import Dashboard from 'features/Dashboard';
 import { useCds } from 'hooks/useCds';
 import './TestPatient.scss';
+import StatusBar from 'components/StatusBar';
 
 // Load the test data and configuration
 import { testData } from './testData.js';
@@ -20,8 +21,9 @@ export function TestPatient() {
     isSymptomatic: false,
     isToggleChanged: false
   });
-  const {output: dashboardInput, isLoadingCdsData } = useCds(patientData, toggleStatus);
+  const {output: dashboardInput, isLoadingCdsData, logStatus } = useCds(patientData, toggleStatus);
   const isLoading = isLoadingCdsData;
+  const applyTime = dashboardInput.applyTime || 0;
   // Extract the data for the requested test patient
   if (params.testName in testData) {
     if (patientData.length === 0) {
@@ -43,15 +45,19 @@ export function TestPatient() {
               <div className="spinner"></div>
             </div>
           )}
-        <Dashboard 
-          input={dashboardInput} 
-          config={config} 
-          setPatientData={setPatientData}
-          toggleStatus={toggleStatus}
-          onToggleStatusChange={setToggleStatus}
+          <Dashboard 
+            input={dashboardInput} 
+            config={config} 
+            setPatientData={setPatientData}
+            toggleStatus={toggleStatus}
+            onToggleStatusChange={setToggleStatus}
+          />
+        </div>
+        <StatusBar
+          logStatus={logStatus}
+          applyTime={applyTime}
         />
-      </div>
-      </div>
+     </div>
     )
   } else {
     // TODO: Route back to TestPatientSelector

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -1,13 +1,17 @@
 // Use a custom logger application
 const LOGGER_HOST = process.env?.REACT_APP_LOGGER_HOST || "http://localhost"
 const LOGGER_PORT = process.env?.REACT_APP_LOGGER_PORT || "4040";
-const logger_url = `${LOGGER_HOST}:${LOGGER_PORT}/log`;
-console.log("Logging at", logger_url);
+
+export const LOGGER_URL = `${LOGGER_HOST}:${LOGGER_PORT}/log`;
+
+export const LOGGER_ENABLED = process.env?.REACT_APP_LOGGER_ENABLED || false;
+
+if (LOGGER_ENABLED) {console.log("Logging at", LOGGER_URL);}
 
 export async function logMsg(msg) {
   console.time('Logged FHIR Data');
   try {
-    const response = await fetch(logger_url, {
+    const response = await fetch(LOGGER_URL, {
       method: 'POST',
       headers: {
         'Accept': 'application/json',
@@ -19,8 +23,11 @@ export async function logMsg(msg) {
       let cachedPostData = response.json();
       console.timeEnd('Logged FHIR Data');
     });
+    return "success";
   } catch (e) {
     console.log("No response from log service")
+    return "fail";
   }
 
 }
+


### PR DESCRIPTION
Normal users at the pilot site do not have access to the browser's inspector panel or debugging console. 
This adds a tiny hidden status bar at the bottom of the dashboard:
![Screenshot 2025-05-02 at 2 59 17 PM](https://github.com/user-attachments/assets/07d95dcf-cd55-44d5-bf90-c66357ccaedf)
which displays the CDS applyTime and (if enabled) the logger status. 
It is hidden (opacity:0) until the user mouses over or selects it via keyboard focus. 
Hovering over the Logger status value will also show a title attribute tooltip which includes the logger url and port. 
The little diamond shows orange while the logger call is pending, green if the logger was successful, red if it failed. 
The status (pending, success, fail) is also shown in the title tooltip. 
