### PR TITLE
add hashrouter based on env var

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,11 +102,11 @@
   "scripts": {
     "analyze": "source-map-explorer 'build/static/js/*.js'",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d build",
+    "deploy": "REACT_APP_DEPLOYMENT=true gh-pages -d build",
     "prestart": "node scripts/prebuild.js",
     "start": "DISABLE_ESLINT_PLUGIN=true BROWSER=none GENERATE_SOURCEMAP=false node scripts/start.js",
     "prebuild": "node scripts/prebuild.js",
-    "build": "DISABLE_ESLINT_PLUGIN=true BROWSER=none GENERATE_SOURCEMAP=true REACT_APP_DEPLOYMENT=true node scripts/build.js",
+    "build": "DISABLE_ESLINT_PLUGIN=true BROWSER=none GENERATE_SOURCEMAP=true node scripts/build.js",
     "prebuild-windows": "rimraf build && node scripts/prebuild.js",
     "build-windows": "set \"DISABLE_ESLINT_PLUGIN=true\" && set \"BROWSER=none\" && set \"GENERATE_SOURCEMAP=true\"  && node scripts/build.js",
     "test": "node scripts/test.js",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "prestart": "node scripts/prebuild.js",
     "start": "DISABLE_ESLINT_PLUGIN=true BROWSER=none GENERATE_SOURCEMAP=false node scripts/start.js",
     "prebuild": "node scripts/prebuild.js",
-    "build": "DISABLE_ESLINT_PLUGIN=true BROWSER=none GENERATE_SOURCEMAP=true node scripts/build.js",
+    "build": "DISABLE_ESLINT_PLUGIN=true BROWSER=none GENERATE_SOURCEMAP=true REACT_APP_DEPLOYMENT=true node scripts/build.js",
     "prebuild-windows": "rimraf build && node scripts/prebuild.js",
     "build-windows": "set \"DISABLE_ESLINT_PLUGIN=true\" && set \"BROWSER=none\" && set \"GENERATE_SOURCEMAP=true\"  && node scripts/build.js",
     "test": "node scripts/test.js",

--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,10 @@
-
 import './App.scss';
 import { Container } from 'react-bootstrap';
 // NOTE: BrowserRouter does not work with Github Pages. For deployment, must 
 // replace with [HashRouter](https://create-react-app.dev/docs/deployment/#notes-on-client-side-routing).
 import {
-  BrowserRouter as Router,
+  BrowserRouter,
+  HashRouter,
   Routes,
   Route
 } from 'react-router-dom';
@@ -17,6 +17,8 @@ import { LaunchSmart } from 'smart/LaunchSmart';
 import { SmartPatient } from 'smart/SmartPatient';
 
 document.body.className = 'bg-light';
+
+const Router = process.env.REACT_APP_DEPLOYMENT == 'true' ? HashRouter : BrowserRouter;
 
 function App() {
   return (


### PR DESCRIPTION
adds an env var to use hashrouter, and uses it when building so that github pages by default uses the hashrouter.