### PR TITLE
Check for code property exists before trying to map result

### DIFF
--- a/src/hooks/useCds/translate.js
+++ b/src/hooks/useCds/translate.js
@@ -515,7 +515,7 @@ function mapLoincCode(result, loincMapping) {
 }
 
 function mapResult(result, loincMapping, testCodeResultMapping) {
-  if (!result.code.coding?.length) { return; }
+  if (!result.code?.coding?.length) { return; }
   mapLoincCode(result, loincMapping);
 
   const customCodes = testCodeResultMapping.find(ts =>


### PR DESCRIPTION
If a DiagnosticReport doesn't have a conclusion code and points to an Observation without a code property, translate.js will give an uncaught runtime exception. This fix adds a check for the existence of the code property before trying to map the result.