### PR TITLE
Drop extra space from test results before translating

### DIFF
--- a/src/hooks/useCds/translate.js
+++ b/src/hooks/useCds/translate.js
@@ -525,7 +525,7 @@ function mapResult(result, loincMapping, testCodeResultMapping) {
   // Should evaluate to false for DiagnosticReports, skipping the result mapping for these resources. We can add logic to
   // map string values to codes values within DiagnosticReport.conclusionCode, if we find that this occurs in practice
   if (customCodes && !result.valueCodeableConcept && result.valueString) {
-    const firstLine = result.valueString.split("\r\n")[0];
+    const firstLine = result.valueString.split("\r\n")[0].trim();
     const mappedCode = customCodes.map.find(cc => cc.text.localeCompare(firstLine, undefined, { sensitivity: 'base' }) === 0);
 
     if (mappedCode) {

--- a/test/translate-test.js
+++ b/test/translate-test.js
@@ -37,6 +37,21 @@ describe('translate', () => {
       )).to.be.true
     });
 
+    it('should add SNOMED CT coding to Observation if valueString contains Reparative/reactive changes with a trailing space', () => {
+      const obs = patientData.find(pd => pd.resourceType === 'Observation' && pd.valueString);
+      const expectedString = "Reparative/reactive changes \r\nNegative for intraepithelial lesion or malignancy";
+      obs.valueString = expectedString
+
+      translateResponse(patientData);
+
+      expect(patientData.some(resource =>
+        resource.resourceType === 'Observation' &&
+        !resource.valueString &&
+        resource.valueCodeableConcept?.text === expectedString &&
+        resource.valueCodeableConcept?.coding?.some(coding => coding.system === 'http://snomed.info/sct' && coding.code === '373887005')
+      )).to.be.true
+    });
+
     it('should translate LOINC code from a DiagnosticReport', () => {
       const dr = patientData.find(pd => pd.resourceType === 'DiagnosticReport');
       const genericHpvTestCode =


### PR DESCRIPTION
Drop preceding and trailing spaces from test result string before being translated, and add a test case to represent the case we encountered with reactive/reparative.

See [CCSMCDS-375](https://jira.mitre.org/browse/CCSMCDS-375) for details about this issue.