### PR TITLE
Increase node heap size to 8gb for Windows build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "prebuild": "node scripts/prebuild.js",
     "build": "DISABLE_ESLINT_PLUGIN=true BROWSER=none GENERATE_SOURCEMAP=true node scripts/build.js",
     "prebuild-windows": "rimraf build && node scripts/prebuild.js",
-    "build-windows": "set \"DISABLE_ESLINT_PLUGIN=true\" && set \"BROWSER=none\" && set \"GENERATE_SOURCEMAP=true\"  && node scripts/build.js",
+    "build-windows": "set \"DISABLE_ESLINT_PLUGIN=true\" && set \"BROWSER=none\" && set \"GENERATE_SOURCEMAP=true\"  && node --max-old-space-size=8192 scripts/build.js",
     "test": "node scripts/test.js",
     "test-mocha": "NODE_ENV=test ./node_modules/.bin/mocha --require @babel/register --reporter spec --recursive",
     "download-value-sets": "node src/services/valuesets/updateValueSetDb.mjs $UMLS_API_KEY",


### PR DESCRIPTION
Add 8gb to node heap size for Windows Build. This is a quick-fix to a resolve an issue our pilot partner was having when trying to build the app with a STRIDES file of about 100mb. We should create a more robust solution for this at some point that could handle even larger sizes of STRIDES data.