### PR TITLE
Bump ccsm-cds-with-tests to version 0.5.2. Bump this version to 0.3.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccsm-cds-dashboard",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccsm-cds-dashboard",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",
@@ -29,7 +29,7 @@
         "buffer": "^6.0.3",
         "camelcase": "^6.2.1",
         "case-sensitive-paths-webpack-plugin": "^2.4.0",
-        "ccsm-cds-with-tests": "^0.5.1",
+        "ccsm-cds-with-tests": "^0.5.2",
         "chai": "^4.3.10",
         "constants-browserify": "^1.0.0",
         "convert-csv-to-json": "^2.0.0",
@@ -9998,9 +9998,9 @@
       }
     },
     "node_modules/ccsm-cds-with-tests": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/ccsm-cds-with-tests/-/ccsm-cds-with-tests-0.5.1.tgz",
-      "integrity": "sha512-pSG1HFhTBXgpQlmTXGU0idapUku4oHccXX4wJd9bWzahBZuYLUuky3SZNP3RAiKRZHqPC3hcGg0LHsrVgQTtSg==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/ccsm-cds-with-tests/-/ccsm-cds-with-tests-0.5.2.tgz",
+      "integrity": "sha512-XQKDRsuHLKmul4tADovB9YZJgzGmNVbfq/NmiEGP6vW1wVTRspS2D87oAft0HpIRFT2tz0ZiRmXhr89WCA4fhw==",
       "license": "Apache-2.0",
       "dependencies": {
         "cql-testing": "^2.5.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccsm-cds-dashboard",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "license": "Apache-2.0",
   "homepage": "/",
   "dependencies": {
@@ -24,7 +24,7 @@
     "buffer": "^6.0.3",
     "camelcase": "^6.2.1",
     "case-sensitive-paths-webpack-plugin": "^2.4.0",
-    "ccsm-cds-with-tests": "^0.5.1",
+    "ccsm-cds-with-tests": "^0.5.2",
     "chai": "^4.3.10",
     "constants-browserify": "^1.0.0",
     "convert-csv-to-json": "^2.0.0",


### PR DESCRIPTION
- Bump ccsm-cds-with-tests to version 0.5.2
- Bump this version to 0.3.10

This should be merged once https://github.com/ccsm-cds-tools/ccsm-cds-with-tests/pull/180 is properly reviewed.