### PR TITLE
Add pathology category code for DiagnosticReport.Search

### DIFF
--- a/src/smart/SmartPatient.js
+++ b/src/smart/SmartPatient.js
@@ -52,7 +52,7 @@ export function SmartPatient() {
       // TODO: Restore commented out API Searches once performance issues have been addressed
 
       // promises.push(client.request(`/Condition?patient=${pid}&category=problem-list-item,medical-history`).then(fhirParser));
-      promises.push(client.request(`/DiagnosticReport?patient=${pid}&category=http://terminology.hl7.org/CodeSystem/v2-0074|Lab`).then(fhirParser));
+      promises.push(client.request(`/DiagnosticReport?patient=${pid}&category=http://terminology.hl7.org/CodeSystem/v2-0074|Lab,http://loinc.org|LP7839-6`).then(fhirParser));
       promises.push(client.request(`/Immunization?patient=${pid}&status=completed&vaccine-code=118,137,165,62`).then(fhirParser));
       // promises.push(client.request(`/MedicationRequest?patient=${pid}&status=completed`).then(fhirParser));
       promises.push(client.request(`/Procedure?patient=${pid}&status=completed&category=http://snomed.info/sct|103693007,http://snomed.info/sct|387713003`).then(fhirParser)); // Search Procedures with category of Diagnostic procedure or Surgical procedure


### PR DESCRIPTION
It was discovered that after a recent EHR update, cytology results were classified by the category code for "Pathology" as opposed to the category code for "Laboratory". This addressed [CCSMCDS-419](https://jira.mitre.org/browse/CCSMCDS-419); see Jira issue for more info. Our pilot partner has made this one line fix within their version of the code, and has been able to once again successfully access cytology results in the CDS.