### PR TITLE
Add Condition Search query for HIV

### DIFF
--- a/src/smart/SmartPatient.js
+++ b/src/smart/SmartPatient.js
@@ -52,6 +52,7 @@ export function SmartPatient() {
       // TODO: Restore commented out API Searches once performance issues have been addressed
 
       // promises.push(client.request(`/Condition?patient=${pid}&category=problem-list-item,medical-history`).then(fhirParser));
+      promises.push(client.request(`/Condition?patient=${pid}&category=problem-list-item,medical-history&code=http://snomed.info/sct|86406008,http://snomed.info/sct|91947003`).then(fhirParser)); // Search for HIV conditions
       promises.push(client.request(`/DiagnosticReport?patient=${pid}&category=http://terminology.hl7.org/CodeSystem/v2-0074|Lab`).then(fhirParser));
       promises.push(client.request(`/Immunization?patient=${pid}&status=completed&vaccine-code=118,137,165,62`).then(fhirParser));
       // promises.push(client.request(`/MedicationRequest?patient=${pid}&status=completed`).then(fhirParser));


### PR DESCRIPTION
Addresses [CCSMCDS-410](https://jira.mitre.org/browse/CCSMCDS-410). From investigating test data from before we turned off API search for Conditions, it appears most HIV patients had one of the following two codes:

```json
{                     "system": "[http://snomed.info/sct]",                     "code": "86406008",                     "display": "Human immunodeficiency virus infection (disorder)"                 }

               
{                     "system": "[http://snomed.info/sct]",                     "code": "91947003",                     "display": "Asymptomatic human immunodeficiency virus infection (disorder)"                 }
```

This PR restores our Condition Search query, but focuses on just the two most common HIV codes. This pattern of searching works appropriately using the Open Epic API: https://fhir.epic.com/Sandbox?api=10314.